### PR TITLE
feat(data): data layer overhaul — point normalization, regulation snapshots, hunter knowledge, scraper activation

### DIFF
--- a/ml/data/loader.py
+++ b/ml/data/loader.py
@@ -26,14 +26,29 @@ def load_point_history(
     species_slug: str,
     unit_code: str,
 ) -> list[dict]:
-    """Load historical min_points_drawn for a state+species+unit combination."""
+    """Load historical min_points_drawn for a state+species+unit combination.
+
+    Returns:
+        list of {year, min_points, effective_points, point_system_type}.
+
+    The forecaster should consume `effective_points` when projecting trends
+    across state lines — raw `min_points` is incomparable between
+    bonus / bonus_squared / pure_preference systems. Within a single
+    (state, species, unit) series the two are equivalent for pure_preference
+    states and proportional for bonus systems, so backward compatibility is
+    preserved for callers that still read `min_points`.
+    """
     try:
         conn = get_connection()
         cur = conn.cursor()
 
         cur.execute(
             """
-            SELECT do.year, do.min_points_drawn
+            SELECT
+                do.year,
+                do.min_points_drawn,
+                do.effective_points,
+                do.point_system_type
             FROM draw_odds do
             JOIN states s ON do.state_id = s.id
             JOIN species sp ON do.species_id = sp.id
@@ -52,7 +67,14 @@ def load_point_history(
         conn.close()
 
         return [
-            {"year": row[0], "min_points": row[1]}
+            {
+                "year": row[0],
+                "min_points": row[1],
+                # Fallback to raw min_points when effective_points hasn't been
+                # backfilled yet (pre-migration data).
+                "effective_points": row[2] if row[2] is not None else row[1],
+                "point_system_type": row[3] or "pure_preference",
+            }
             for row in rows
         ]
     except Exception as e:
@@ -129,7 +151,12 @@ def load_draw_history(
 
 
 def load_training_data():
-    """Load all draw odds data for bulk training."""
+    """Load all draw odds data for bulk training.
+
+    Includes the normalized point fields (effective_points, point_system_type)
+    so the model can either project all data onto a common axis or partition
+    training by point_system_type.
+    """
     try:
         import pandas as pd
 
@@ -143,6 +170,8 @@ def load_training_data():
                 do.total_applicants,
                 do.total_tags,
                 do.min_points_drawn,
+                do.effective_points,
+                do.point_system_type,
                 do.draw_rate,
                 do.resident_type,
                 do.weapon_type

--- a/scripts/enrich-public-land.ts
+++ b/scripts/enrich-public-land.ts
@@ -1,0 +1,331 @@
+/**
+ * Enrich Public Land — BLM + USFS → hunt_units + public_land_parcels
+ *
+ * For each western/eastern state in our DB, fetches the agency's public
+ * land overlay (BLM Surface Management Agency, USFS National Forest
+ * boundaries, NPS Park Service, state-managed WMAs where available),
+ * intersects it with each hunt_unit's footprint, and writes:
+ *
+ *   1) one row per parcel into `public_land_parcels` with the list of
+ *      hunt unit codes it overlaps
+ *   2) a recomputed `hunt_units.public_land_pct` based on the aggregate
+ *      acreage of overlapping public parcels divided by unit acreage
+ *
+ * Data sources (all free, ArcGIS REST or open GeoJSON):
+ *   - BLM Surface Management Agency:
+ *       https://gis.blm.gov/arcgis/rest/services/admin_boundaries/
+ *       BLM_Natl_SMA_LimitedScale/MapServer/0/query
+ *   - USFS National Forest System Boundaries:
+ *       https://apps.fs.usda.gov/arcx/rest/services/EDW/
+ *       EDW_AdministrativeForest_01/MapServer/0/query
+ *   - NPS Boundaries:
+ *       https://services.arcgis.com/T8oZ3RYDowFc4n7l/arcgis/rest/services/
+ *       NPS_Park_Boundaries/FeatureServer/0/query
+ *   - USFWS National Wildlife Refuges:
+ *       https://gis.fws.gov/arcgis/rest/services/FWS_Refuge_Boundaries/
+ *       MapServer/0/query
+ *   - State-managed lands: per-state ArcGIS endpoints (e.g.
+ *       CO: cpw.maps.arcgis.com; NV: gis-ndow.arcgis.com)
+ *
+ * IMPORTANT — this script is structured for the real workflow but the
+ * actual spatial-join step requires PostGIS or a Turf.js polygon-intersect
+ * pass. Without PostGIS available we keep a "fetch + persist parcel
+ * metadata" pass that lays the data foundation; the spatial-intersect
+ * upgrade is the follow-up step (tracked in TODO at bottom of file).
+ *
+ * Run: pnpm tsx scripts/enrich-public-land.ts [--state CO]
+ */
+
+import { db } from "../src/lib/db";
+import {
+  states,
+  huntUnits,
+} from "../src/lib/db/schema";
+import { publicLandParcels } from "../src/lib/db/schema/hunter-knowledge";
+import { eq } from "drizzle-orm";
+
+interface ArcGisQueryOptions {
+  url: string;
+  where?: string;
+  outFields?: string;
+  returnGeometry?: boolean;
+  inSR?: number;
+  outSR?: number;
+}
+
+interface ArcGisFeature {
+  attributes: Record<string, unknown>;
+  geometry?: {
+    rings?: number[][][];
+    type?: string;
+    spatialReference?: { wkid: number };
+  };
+}
+
+interface ArcGisResponse {
+  features: ArcGisFeature[];
+  exceededTransferLimit?: boolean;
+}
+
+const AGENCY_ENDPOINTS = {
+  BLM: "https://gis.blm.gov/arcgis/rest/services/admin_boundaries/BLM_Natl_SMA_LimitedScale/MapServer/0/query",
+  USFS: "https://apps.fs.usda.gov/arcx/rest/services/EDW/EDW_AdministrativeForest_01/MapServer/0/query",
+  NPS: "https://services.arcgis.com/T8oZ3RYDowFc4n7l/arcgis/rest/services/NPS_Park_Boundaries/FeatureServer/0/query",
+  USFWS: "https://gis.fws.gov/arcgis/rest/services/FWS_Refuge_Boundaries/MapServer/0/query",
+} as const;
+
+const LOG_PREFIX = "[enrich:public-land]";
+
+/**
+ * Page through an ArcGIS layer's features for a given WHERE clause,
+ * respecting the server's transfer limit. Returns an array of features
+ * with attribute payloads (geometry stripped after centroid extraction).
+ */
+async function fetchArcGisFeatures(
+  opts: ArcGisQueryOptions
+): Promise<ArcGisFeature[]> {
+  const allFeatures: ArcGisFeature[] = [];
+  let offset = 0;
+  const pageSize = 1000;
+
+  while (true) {
+    const params = new URLSearchParams({
+      where: opts.where ?? "1=1",
+      outFields: opts.outFields ?? "*",
+      returnGeometry: String(opts.returnGeometry ?? true),
+      f: "json",
+      resultOffset: String(offset),
+      resultRecordCount: String(pageSize),
+      ...(opts.inSR ? { inSR: String(opts.inSR) } : {}),
+      ...(opts.outSR ? { outSR: String(opts.outSR ?? 4326) } : { outSR: "4326" }),
+    });
+
+    const url = `${opts.url}?${params.toString()}`;
+    const res = await fetch(url, {
+      headers: { "User-Agent": "HuntLogic-Bot/1.0" },
+    });
+    if (!res.ok) {
+      throw new Error(`ArcGIS fetch failed (${res.status}): ${url}`);
+    }
+    const json = (await res.json()) as ArcGisResponse;
+    if (!json.features) break;
+    allFeatures.push(...json.features);
+    if (!json.exceededTransferLimit || json.features.length < pageSize) {
+      break;
+    }
+    offset += json.features.length;
+  }
+
+  return allFeatures;
+}
+
+/**
+ * Compute a rough centroid of a polygon's first ring. Acceptable accuracy
+ * for "where is this parcel" purposes; not a substitute for PostGIS for
+ * any real spatial-join work.
+ */
+function centroidOfRings(rings: number[][][] | undefined):
+  | { lat: number; lon: number }
+  | null {
+  if (!rings || rings.length === 0) return null;
+  const outer = rings[0];
+  if (!outer || outer.length === 0) return null;
+  let sumX = 0;
+  let sumY = 0;
+  for (const pt of outer) {
+    sumX += pt[0]!;
+    sumY += pt[1]!;
+  }
+  return { lon: sumX / outer.length, lat: sumY / outer.length };
+}
+
+function bboxOfRings(rings: number[][][] | undefined):
+  | [number, number, number, number]
+  | null {
+  if (!rings || rings.length === 0) return null;
+  let minLon = Infinity;
+  let minLat = Infinity;
+  let maxLon = -Infinity;
+  let maxLat = -Infinity;
+  for (const ring of rings) {
+    for (const [lon, lat] of ring) {
+      if (lon === undefined || lat === undefined) continue;
+      if (lon < minLon) minLon = lon;
+      if (lon > maxLon) maxLon = lon;
+      if (lat < minLat) minLat = lat;
+      if (lat > maxLat) maxLat = lat;
+    }
+  }
+  return [minLon, minLat, maxLon, maxLat];
+}
+
+async function ingestAgencyForState(
+  stateCode: string,
+  stateId: string,
+  agency: keyof typeof AGENCY_ENDPOINTS,
+  whereClauseForState: string,
+  parcelCodeField: string,
+  nameField: string,
+  acreageField: string
+): Promise<number> {
+  console.log(`${LOG_PREFIX}   ${agency}: querying for ${stateCode}...`);
+  const features = await fetchArcGisFeatures({
+    url: AGENCY_ENDPOINTS[agency],
+    where: whereClauseForState,
+    outFields: `${parcelCodeField},${nameField},${acreageField}`,
+    returnGeometry: true,
+  });
+  console.log(`${LOG_PREFIX}     received ${features.length} features`);
+
+  let inserted = 0;
+  for (const feat of features) {
+    const attrs = feat.attributes ?? {};
+    const parcelCode = String(attrs[parcelCodeField] ?? "");
+    const name = (attrs[nameField] as string | undefined) ?? null;
+    const acreage =
+      typeof attrs[acreageField] === "number"
+        ? (attrs[acreageField] as number)
+        : null;
+    if (!parcelCode) continue;
+
+    const centroid = centroidOfRings(feat.geometry?.rings);
+    const bbox = bboxOfRings(feat.geometry?.rings);
+
+    await db.insert(publicLandParcels).values({
+      stateId,
+      landAgency: agency,
+      name,
+      parcelCode,
+      acreage,
+      // Spatial join with hunt_units happens in a follow-up PostGIS pass;
+      // we leave this empty for now and let the enrichment job populate
+      // it once the geometry pipeline is wired.
+      overlapsUnitCodes: [],
+      huntingAllowed: agency === "NPS" ? false : true,
+      accessNotes: null,
+      sourceDataset: `${agency} (ArcGIS REST)`,
+      sourceUrl: AGENCY_ENDPOINTS[agency],
+      geomCentroid: centroid,
+      boundsBbox: bbox,
+      lastRefreshed: new Date(),
+    });
+    inserted++;
+  }
+  console.log(`${LOG_PREFIX}     persisted ${inserted} parcels`);
+  return inserted;
+}
+
+async function enrichState(stateCode: string): Promise<void> {
+  const [state] = await db
+    .select()
+    .from(states)
+    .where(eq(states.code, stateCode))
+    .limit(1);
+  if (!state) {
+    console.log(`${LOG_PREFIX} State not found: ${stateCode} — skipping`);
+    return;
+  }
+
+  console.log(`${LOG_PREFIX} Enriching ${stateCode}...`);
+
+  // ArcGIS field names + state-filter clauses (the BLM SMA layer uses
+  // STATE_NAME; USFS uses ADMINFORESTID encoding; NPS uses STATE; USFWS
+  // uses STATE_ADM). We hand-encode the right WHERE for each.
+  try {
+    await ingestAgencyForState(
+      stateCode,
+      state.id,
+      "BLM",
+      `ADMIN_ST='${stateCode}'`,
+      "OBJECTID",
+      "ADMIN_AGEN",
+      "GIS_ACRES"
+    );
+  } catch (err) {
+    console.error(`${LOG_PREFIX}   BLM error for ${stateCode}: ${err}`);
+  }
+
+  try {
+    await ingestAgencyForState(
+      stateCode,
+      state.id,
+      "USFS",
+      // USFS state filter is more permissive — most regions use FORESTNAME
+      // and aren't filtered by state directly; we leave WHERE open and
+      // let the per-state spatial pass narrow it.
+      "1=1",
+      "FORESTORGCODE",
+      "FORESTNAME",
+      "GIS_ACRES"
+    );
+  } catch (err) {
+    console.error(`${LOG_PREFIX}   USFS error for ${stateCode}: ${err}`);
+  }
+
+  try {
+    await ingestAgencyForState(
+      stateCode,
+      state.id,
+      "NPS",
+      `STATE='${stateCode}'`,
+      "UNIT_CODE",
+      "UNIT_NAME",
+      "GIS_ACRES"
+    );
+  } catch (err) {
+    console.error(`${LOG_PREFIX}   NPS error for ${stateCode}: ${err}`);
+  }
+
+  try {
+    await ingestAgencyForState(
+      stateCode,
+      state.id,
+      "USFWS",
+      `STATE_ADM='${stateCode}'`,
+      "CMPLX_NAME",
+      "ORGNAME",
+      "ACRES"
+    );
+  } catch (err) {
+    console.error(`${LOG_PREFIX}   USFWS error for ${stateCode}: ${err}`);
+  }
+
+  console.log(`${LOG_PREFIX} Done with ${stateCode}.`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const stateArg = args.find((a) => a.startsWith("--state="))?.split("=")[1];
+  const stateFromShort = args.findIndex((a) => a === "--state");
+  const explicitState =
+    stateArg ?? (stateFromShort >= 0 ? args[stateFromShort + 1] : undefined);
+
+  const targets = explicitState
+    ? [explicitState.toUpperCase()]
+    : ["CO", "WY", "AZ", "NV", "UT", "ID", "OR", "MT", "NM", "WA", "AK", "CA"];
+
+  for (const code of targets) {
+    try {
+      await enrichState(code);
+    } catch (err) {
+      console.error(`${LOG_PREFIX} Fatal in ${code}: ${err}`);
+    }
+  }
+
+  console.log(`${LOG_PREFIX} all done`);
+  process.exit(0);
+
+  // -------------------------------------------------------------------------
+  // TODO (spatial-join upgrade): after PostGIS is enabled in the prod DB,
+  // add an ST_Intersects pass that joins public_land_parcels.geom with
+  // hunt_units.geom (when we backfill geometries from state GIS portals),
+  // populates public_land_parcels.overlaps_unit_codes, and recomputes
+  // hunt_units.public_land_pct from the sum of overlapping acreage.
+  // -------------------------------------------------------------------------
+  void huntUnits;
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/seed-data-sources-eastern.ts
+++ b/scripts/seed-data-sources-eastern.ts
@@ -1,0 +1,684 @@
+/**
+ * Seed: Eastern State Data Sources
+ *
+ * Eastern + southern + midwest state agencies for whitetail deer, turkey,
+ * waterfowl, bear, and small game. Most of these states are OTC-heavy with
+ * county-based "zones" rather than the unit-based draw system of the west;
+ * the schema (`huntUnits` with `unitType` carried in `config`) accommodates
+ * this without modification.
+ *
+ * Coverage:
+ *   GA, PA, TX, FL, NC, NY, OH, MI, VA, TN, AL, MS, LA, AR, SC, IL, IN, WI, MN, MO
+ *
+ * Run: pnpm tsx scripts/seed-data-sources-eastern.ts
+ */
+
+import { db } from "../src/lib/db";
+import { dataSources } from "../src/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+interface EasternSourceSeed {
+  name: string;
+  sourceType: string;
+  authorityTier: number;
+  url: string;
+  refreshCadence: "daily" | "weekly" | "monthly" | "annual" | "manual";
+  scraperConfig: Record<string, unknown>;
+  notes: string;
+}
+
+const SOURCES: EasternSourceSeed[] = [
+  // ---------------------------------------------------------------------------
+  // GEORGIA
+  // ---------------------------------------------------------------------------
+  {
+    name: "Georgia DNR — Hunting Regulations + Harvest Reports",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://georgiawildlife.com",
+    refreshCadence: "monthly",
+    notes:
+      "GA WRD publishes annual hunting guides + WMA-specific rules + deer harvest summaries (PDF).",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://georgiawildlife.com",
+      state_code: "GA",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/regulations/hunting",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+        {
+          path: "/research-publications",
+          parser: "harvest_report",
+          params: {},
+          doc_type: "harvest_report",
+          schedule: "0 5 1 9 *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // PENNSYLVANIA
+  // ---------------------------------------------------------------------------
+  {
+    name: "Pennsylvania Game Commission — Harvest Reports + Regulations",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.pgc.pa.gov",
+    refreshCadence: "monthly",
+    notes:
+      "PGC publishes the Hunting & Trapping Digest (annual) and detailed deer/turkey/elk harvest summaries.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.pgc.pa.gov",
+      state_code: "PA",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/HuntTrap/HuntingTrappingDigest/Pages/default.aspx",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 15 6 *",
+        },
+        {
+          path: "/Wildlife/WildlifeSpecies/Pages/HarvestData.aspx",
+          parser: "harvest_report",
+          params: {},
+          doc_type: "harvest_report",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // TEXAS
+  // ---------------------------------------------------------------------------
+  {
+    name: "Texas Parks & Wildlife — Outdoor Annual",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://tpwd.texas.gov",
+    refreshCadence: "weekly",
+    notes:
+      "TPWD Outdoor Annual is the canonical regs source. Big-game harvest reports per county.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://tpwd.texas.gov",
+      state_code: "TX",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/regulations/outdoor-annual/hunting",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/huntwild/hunt/research/big-game-harvest",
+          parser: "harvest_report",
+          params: {},
+          doc_type: "harvest_report",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // FLORIDA
+  // ---------------------------------------------------------------------------
+  {
+    name: "Florida FWC — Hunting & Regulations",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://myfwc.com",
+    refreshCadence: "monthly",
+    notes: "FWC's hunting regs cover WMAs, zones (A-D), and the unique dog-deer hunting tradition.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://myfwc.com",
+      state_code: "FL",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting/regulations/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+        {
+          path: "/hunting/deer/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // NORTH CAROLINA
+  // ---------------------------------------------------------------------------
+  {
+    name: "North Carolina Wildlife Resources Commission",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.ncwildlife.org",
+    refreshCadence: "monthly",
+    notes: "NCWRC posts the Inland Game Lands regs + Annual Big-Game Harvest Summary.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.ncwildlife.org",
+      state_code: "NC",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/Hunting/Regulations",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // NEW YORK
+  // ---------------------------------------------------------------------------
+  {
+    name: "New York DEC — Big Game Hunting",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.dec.ny.gov",
+    refreshCadence: "monthly",
+    notes:
+      "NYDEC publishes Big Game Hunting regs + annual Deer/Bear/Turkey Harvest Summaries.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.dec.ny.gov",
+      state_code: "NY",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/things-to-do/hunting/deer",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/things-to-do/hunting/big-game/harvest-report",
+          parser: "harvest_report",
+          params: {},
+          doc_type: "harvest_report",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // OHIO
+  // ---------------------------------------------------------------------------
+  {
+    name: "Ohio DNR Division of Wildlife — Hunting",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://ohiodnr.gov",
+    refreshCadence: "monthly",
+    notes: "Ohio's deer/turkey harvest dashboards are updated annually.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://ohiodnr.gov",
+      state_code: "OH",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/discover-and-learn/safety-conservation/about-odnr/division-of-wildlife/hunting",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // MICHIGAN
+  // ---------------------------------------------------------------------------
+  {
+    name: "Michigan DNR — Hunting Digest",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.michigan.gov/dnr",
+    refreshCadence: "monthly",
+    notes:
+      "Michigan publishes the Hunting Digest annually + deer/elk/bear harvest summaries.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.michigan.gov",
+      state_code: "MI",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/dnr/things-to-do/hunting",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // VIRGINIA
+  // ---------------------------------------------------------------------------
+  {
+    name: "Virginia DWR — Hunting + Elk",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://dwr.virginia.gov",
+    refreshCadence: "monthly",
+    notes:
+      "VA DWR — new elk lottery added; deer/turkey harvest reports + regs.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://dwr.virginia.gov",
+      state_code: "VA",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting/regulations/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+        {
+          path: "/wildlife/elk/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // TENNESSEE
+  // ---------------------------------------------------------------------------
+  {
+    name: "Tennessee Wildlife Resources Agency",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.tn.gov/twra",
+    refreshCadence: "monthly",
+    notes: "TWRA publishes annual hunting guide and harvest summaries.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.tn.gov",
+      state_code: "TN",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/twra/hunting.html",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // ALABAMA, MISSISSIPPI, LOUISIANA, ARKANSAS, SOUTH CAROLINA
+  // ---------------------------------------------------------------------------
+  {
+    name: "Alabama Dept of Conservation",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.outdooralabama.com",
+    refreshCadence: "monthly",
+    notes: "Alabama publishes annual hunting guide.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.outdooralabama.com",
+      state_code: "AL",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/seasons-and-bag-limits",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "Mississippi Dept of Wildlife, Fisheries & Parks",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.mdwfp.com",
+    refreshCadence: "monthly",
+    notes: "MDWFP hunting regs + deer/turkey harvest.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.mdwfp.com",
+      state_code: "MS",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/wildlife-hunting/regulations/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "Louisiana Dept of Wildlife & Fisheries",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.wlf.louisiana.gov",
+    refreshCadence: "monthly",
+    notes: "LWF hunting regs + deer area boundaries.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.wlf.louisiana.gov",
+      state_code: "LA",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/page/hunting-regulations",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "Arkansas Game & Fish Commission",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.agfc.com",
+    refreshCadence: "monthly",
+    notes: "AGFC hunting guidebook + alligator/elk draw + deer harvest.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.agfc.com",
+      state_code: "AR",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting/regulations/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "South Carolina DNR",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.dnr.sc.gov",
+    refreshCadence: "monthly",
+    notes: "SCDNR — game zones, deer/turkey/duck regs.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.dnr.sc.gov",
+      state_code: "SC",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/regs/hunting.html",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // MIDWEST: WI, MN, IL, IN, MO, IA
+  // ---------------------------------------------------------------------------
+  {
+    name: "Wisconsin DNR — Hunting",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://dnr.wisconsin.gov",
+    refreshCadence: "monthly",
+    notes: "Wisconsin's deer/bear/turkey programs + Hunters Choice (DMU) system.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://dnr.wisconsin.gov",
+      state_code: "WI",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/topic/Hunt/regulations.html",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "Minnesota DNR",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.dnr.state.mn.us",
+    refreshCadence: "monthly",
+    notes: "Minnesota's deer permit area system + bear lottery + moose history.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.dnr.state.mn.us",
+      state_code: "MN",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/regulations/hunting/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "Illinois DNR",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://dnr.illinois.gov",
+    refreshCadence: "monthly",
+    notes: "Illinois — shotgun-only for deer statewide; archery + muzzleloader lottery.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://dnr.illinois.gov",
+      state_code: "IL",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting.html",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "Indiana DNR — Hunting",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.in.gov/dnr",
+    refreshCadence: "monthly",
+    notes: "Indiana — shotgun + rifle (for HSCC since 2007) + crossbow.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://www.in.gov",
+      state_code: "IN",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/dnr/fish-and-wildlife/hunting-and-trapping/",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+  {
+    name: "Missouri Department of Conservation",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://mdc.mo.gov",
+    refreshCadence: "monthly",
+    notes: "MDC — turkey + deer + elk (small herd). Many free apprentice-friendly licenses.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://mdc.mo.gov",
+      state_code: "MO",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting-trapping",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "regulation",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+];
+
+async function upsert(source: EasternSourceSeed): Promise<void> {
+  const existing = await db
+    .select()
+    .from(dataSources)
+    .where(eq(dataSources.name, source.name))
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .update(dataSources)
+      .set({
+        sourceType: source.sourceType,
+        authorityTier: source.authorityTier,
+        url: source.url,
+        scraperConfig: source.scraperConfig,
+        refreshCadence: source.refreshCadence,
+        status: "active",
+        enabled: true,
+        updatedAt: new Date(),
+      })
+      .where(eq(dataSources.id, existing[0]!.id));
+    console.log(`  ✓ Updated: ${source.name}`);
+    return;
+  }
+
+  await db.insert(dataSources).values({
+    name: source.name,
+    sourceType: source.sourceType,
+    authorityTier: source.authorityTier,
+    url: source.url,
+    scraperConfig: source.scraperConfig,
+    refreshCadence: source.refreshCadence,
+    status: "active",
+    enabled: true,
+  });
+  console.log(`  + Created: ${source.name}`);
+}
+
+async function main(): Promise<void> {
+  console.log("Seeding eastern/southern/midwest state data sources...");
+  console.log("");
+  for (const source of SOURCES) {
+    try {
+      await upsert(source);
+    } catch (error) {
+      console.error(`  ✗ Failed: ${source.name}: ${error}`);
+    }
+  }
+  console.log("");
+  console.log(`Done. ${SOURCES.length} eastern-region sources seeded.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/seed-data-sources-western.ts
+++ b/scripts/seed-data-sources-western.ts
@@ -1,0 +1,537 @@
+/**
+ * Seed: Western State Data Sources
+ *
+ * Populates `data_sources` for the 11 western states with scraper configs
+ * pointing at the canonical agency endpoints. The existing scheduler picks
+ * these up and creates BullMQ repeatable jobs based on refreshCadence.
+ *
+ * Idempotent: uses upsert keyed on (name) so re-runs replace stale config
+ * rather than duplicating rows.
+ *
+ * Each entry's scraper_config matches the existing src/services/ingestion
+ * types: { adapter, base_url, endpoints[], rate_limit, retry }.
+ *
+ * Run: pnpm tsx scripts/seed-data-sources-western.ts
+ */
+
+import { db } from "../src/lib/db";
+import { dataSources } from "../src/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+interface WesternSourceSeed {
+  name: string;
+  sourceType: string;
+  authorityTier: number;
+  url: string;
+  refreshCadence: "daily" | "weekly" | "monthly" | "annual" | "manual";
+  scraperConfig: Record<string, unknown>;
+  notes: string;
+}
+
+const SOURCES: WesternSourceSeed[] = [
+  // ---------------------------------------------------------------------------
+  // Idaho — Hunt Planner exposes JSON/CSV/Excel/XML. By far the easiest western
+  // state to ingest. 28 years of history (1998–2026) via the same API surface.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Idaho Fish & Game — Hunt Planner (JSON)",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://idfg.idaho.gov/ifwis/huntplanner/odds/",
+    refreshCadence: "weekly",
+    notes:
+      "ID Hunt Planner has JSON/CSV/Excel/XML exports per species/year/unit. Pure-random draw (no point system).",
+    scraperConfig: {
+      adapter: "api_json",
+      base_url: "https://idfg.idaho.gov/ifwis/huntplanner/odds",
+      state_code: "ID",
+      rate_limit: { requests_per_minute: 20 },
+      retry: { max_attempts: 3, backoff_ms: 5000 },
+      timeout_ms: 30000,
+      endpoints: [
+        {
+          path: "/elk/{{current_year}}.json",
+          parser: "draw_odds_csv",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1", // weekly Monday 5am
+        },
+        {
+          path: "/deer/{{current_year}}.json",
+          parser: "draw_odds_csv",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/antelope/{{current_year}}.json",
+          parser: "draw_odds_csv",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/moose/{{current_year}}.json",
+          parser: "draw_odds_csv",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/sheep/{{current_year}}.json",
+          parser: "draw_odds_csv",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/goat/{{current_year}}.json",
+          parser: "draw_odds_csv",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Nevada — NDOW publishes annual hunt statistics as XLSX. New file per year,
+  // posted ~6 weeks after the spring draw. Bonus² system.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Nevada Department of Wildlife — Hunt Statistics (XLSX)",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://ndow.org/blog/hunt-statistics/",
+    refreshCadence: "monthly",
+    notes:
+      "NV NDOW posts annual XLSX hunt-stats roll-ups. Bonus² point math.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://ndow.org",
+      state_code: "NV",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/blog/hunt-statistics/",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 6 1,15 * *", // 1st + 15th of each month
+          selectors: {
+            article_links: "a[href$='.xlsx'], a[href*='hunt-stat']",
+          },
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Colorado — CPW collections portal holds the full PDF history (1969+).
+  // Pure-preference system. 22 years of digitized data.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Colorado Parks & Wildlife — Hunting Statistics (PDF)",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://cpw.cvlcollections.org",
+    refreshCadence: "weekly",
+    notes:
+      "CPW collections portal: historical PDFs for draw odds + harvest stats. Pure-preference points.",
+    scraperConfig: {
+      adapter: "pdf_download",
+      base_url: "https://cpw.cvlcollections.org",
+      state_code: "CO",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 120000,
+      endpoints: [
+        {
+          path: "/search?collection=hunt-statistics&year={{current_year}}",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/search?collection=harvest-reports&year={{current_year}}",
+          parser: "harvest_report",
+          params: {},
+          doc_type: "harvest_report",
+          schedule: "0 5 * * 1",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Wyoming — WGFD PDFs at predictable URLs by species + year.
+  // Pure-preference, separate resident/nonresident pools.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Wyoming Game & Fish — Draw Results (PDF)",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://wgfd.wyo.gov",
+    refreshCadence: "weekly",
+    notes: "WY WGFD PDF draw reports by species/year. Pure preference points.",
+    scraperConfig: {
+      adapter: "pdf_download",
+      base_url: "https://wgfd.wyo.gov",
+      state_code: "WY",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/get-involved/applications-and-draws/elk-draw-results",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/get-involved/applications-and-draws/deer-draw-results",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/get-involved/applications-and-draws/antelope-draw-results",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/get-involved/applications-and-draws/moose-draw-results",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+        {
+          path: "/get-involved/applications-and-draws/bighorn-sheep-draw-results",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Arizona — AZGFD draw portal + harvest reports.
+  // Bonus (loyalty capped at +5).
+  // ---------------------------------------------------------------------------
+  {
+    name: "Arizona Game & Fish — Draw Portal",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://draw.azgfd.com",
+    refreshCadence: "weekly",
+    notes: "AZ draw portal. Bonus point system with +5 loyalty cap.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://draw.azgfd.com",
+      state_code: "AZ",
+      rate_limit: { requests_per_minute: 6 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunt-permit-tag-draw",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Utah — UDWR draw recap (PDF legacy + JS portal). 50/50 weighted preference.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Utah Division of Wildlife Resources — Draw Recap",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://wildlife.utah.gov",
+    refreshCadence: "weekly",
+    notes:
+      "UT UDWR. 50/50 weighted preference (half tags random, half by points).",
+    scraperConfig: {
+      adapter: "pdf_download",
+      base_url: "https://wildlife.utah.gov",
+      state_code: "UT",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting/main-hunting-page/big-game-application/big-game-draw-recap.html",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Oregon — ODFW exposes XLSX draw results 2017+. Pure preference.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Oregon Dept of Fish & Wildlife — Controlled Hunt Statistics",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://myodfw.com",
+    refreshCadence: "weekly",
+    notes:
+      "OR ODFW. XLSX exports for controlled hunts. Pure preference. 2026 WMU restructure may invalidate older keys.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://myodfw.com",
+      state_code: "OR",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/articles/oregon-controlled-hunt-statistics",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+          selectors: {
+            xlsx_links: "a[href$='.xlsx']",
+          },
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Montana — FWP draw stats portal is JS-rendered (need headless browser).
+  // Tag for adapter to switch to headless once that's wired up.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Montana Fish, Wildlife & Parks — Drawing Statistics",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://myfwp.mt.gov/fwpPub/drawingStatistics",
+    refreshCadence: "monthly",
+    notes:
+      "MT FWP. JS-rendered SPA; requires headless browser to extract draw stats. Currently scraper logs and skips.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://myfwp.mt.gov",
+      state_code: "MT",
+      rate_limit: { requests_per_minute: 6 },
+      retry: { max_attempts: 2, backoff_ms: 10000 },
+      timeout_ms: 90000,
+      endpoints: [
+        {
+          path: "/fwpPub/drawingStatistics",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // New Mexico — NMDGF posts XLSX draw results. Pure-random draw, no points.
+  // ---------------------------------------------------------------------------
+  {
+    name: "New Mexico Game & Fish — Draw Results (XLSX)",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://wildlife.dgf.nm.gov",
+    refreshCadence: "weekly",
+    notes:
+      "NM NMDGF XLSX. Pure-random draw — point_system_type='random'.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://wildlife.dgf.nm.gov",
+      state_code: "NM",
+      rate_limit: { requests_per_minute: 10 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting/draw-results/",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 * * 1",
+          selectors: {
+            xlsx_links: "a[href$='.xlsx'], a[href*='draw-result']",
+          },
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Washington — WDFW Power BI dashboards stale since 2021. Flagging for ops
+  // attention; configure once a replacement source is identified.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Washington Dept of Fish & Wildlife — Special Permits",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://wdfw.wa.gov",
+    refreshCadence: "monthly",
+    notes:
+      "WA WDFW Power BI dashboards have been stale since 2021. Source needs replacement; press-release scrape as fallback.",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://wdfw.wa.gov",
+      state_code: "WA",
+      rate_limit: { requests_per_minute: 6 },
+      retry: { max_attempts: 2, backoff_ms: 15000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/hunting/permits/special-hunt-permits",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Alaska — ADFG draw supplements as PDF. Largely subsistence/draw.
+  // ---------------------------------------------------------------------------
+  {
+    name: "Alaska Dept of Fish & Game — Draw Supplement (PDF)",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://www.adfg.alaska.gov",
+    refreshCadence: "annual",
+    notes:
+      "AK ADFG draw supplements. Annual PDF. Subsistence/lottery rules differ heavily from western big-game norms.",
+    scraperConfig: {
+      adapter: "pdf_download",
+      base_url: "https://www.adfg.alaska.gov",
+      state_code: "AK",
+      rate_limit: { requests_per_minute: 6 },
+      retry: { max_attempts: 3, backoff_ms: 10000 },
+      timeout_ms: 120000,
+      endpoints: [
+        {
+          path: "/static/hunting/regulations/pdfs/draw_supplement.pdf",
+          parser: "draw_odds_table",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 1 4 *", // Apr 1 annually
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // California — CDFW. Largely OTC + LE draw. Schema slot held; ingestion
+  // is stub for now (existing repo had no CA seed).
+  // ---------------------------------------------------------------------------
+  {
+    name: "California Dept of Fish & Wildlife — Big Game Draw",
+    sourceType: "state_agency",
+    authorityTier: 1,
+    url: "https://wildlife.ca.gov",
+    refreshCadence: "monthly",
+    notes:
+      "CA CDFW. Mix of OTC and limited-entry; ingestion is stub (needs PDF locating).",
+    scraperConfig: {
+      adapter: "web_scraper",
+      base_url: "https://wildlife.ca.gov",
+      state_code: "CA",
+      rate_limit: { requests_per_minute: 6 },
+      retry: { max_attempts: 2, backoff_ms: 15000 },
+      timeout_ms: 60000,
+      endpoints: [
+        {
+          path: "/Hunting/Big-Game/Drawing",
+          parser: "regulation_text",
+          params: {},
+          doc_type: "draw_report",
+          schedule: "0 5 1 * *",
+        },
+      ],
+    },
+  },
+];
+
+async function upsertSource(source: WesternSourceSeed): Promise<void> {
+  const existing = await db
+    .select()
+    .from(dataSources)
+    .where(eq(dataSources.name, source.name))
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .update(dataSources)
+      .set({
+        sourceType: source.sourceType,
+        authorityTier: source.authorityTier,
+        url: source.url,
+        scraperConfig: source.scraperConfig,
+        refreshCadence: source.refreshCadence,
+        status: "active",
+        enabled: true,
+        updatedAt: new Date(),
+      })
+      .where(eq(dataSources.id, existing[0]!.id));
+    console.log(`  ✓ Updated: ${source.name}`);
+    return;
+  }
+
+  await db.insert(dataSources).values({
+    name: source.name,
+    sourceType: source.sourceType,
+    authorityTier: source.authorityTier,
+    url: source.url,
+    scraperConfig: source.scraperConfig,
+    refreshCadence: source.refreshCadence,
+    status: "active",
+    enabled: true,
+  });
+  console.log(`  + Created: ${source.name}`);
+}
+
+async function main(): Promise<void> {
+  console.log("Seeding western state data sources...");
+  console.log("");
+
+  for (const source of SOURCES) {
+    try {
+      await upsertSource(source);
+    } catch (error) {
+      console.error(`  ✗ Failed: ${source.name}: ${error}`);
+    }
+  }
+
+  console.log("");
+  console.log(`Done. ${SOURCES.length} western state sources seeded.`);
+  console.log("Run the scheduler (`pnpm run ingestion:start`) to activate them.");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/seed-hunter-education.ts
+++ b/scripts/seed-hunter-education.ts
@@ -1,0 +1,544 @@
+/**
+ * Seed: Hunter Education Requirements (all 50 states)
+ *
+ * Populates `hunter_education_requirements` with one row per state. Data is
+ * drawn from each state's wildlife agency website as of 2026. Ops should
+ * re-verify annually — set `last_verified` on each update.
+ *
+ * The concierge uses these rows to answer "I'm new — do I need hunter ed
+ * in {state}?" without hallucinating.
+ *
+ * Run: pnpm tsx scripts/seed-hunter-education.ts
+ */
+
+import { db } from "../src/lib/db";
+import { states } from "../src/lib/db/schema";
+import { hunterEducationRequirements } from "../src/lib/db/schema/hunter-knowledge";
+import { eq } from "drizzle-orm";
+
+interface AcceptedCourse {
+  provider: string;
+  format: "in_person" | "online" | "hybrid";
+  cost: number;
+  url: string;
+  notes?: string;
+}
+
+interface HunterEdSeed {
+  stateCode: string;
+  requiredFor:
+    | "all_first_time"
+    | "born_on_or_after"
+    | "age_only"
+    | "none";
+  bornOnOrAfter?: number;
+  minimumAge?: number;
+  apprenticeAllowed: boolean;
+  apprenticeMaxYears?: number;
+  acceptedCourses: AcceptedCourse[];
+  onlineAllowed: boolean;
+  fieldDayRequired: boolean;
+  typicalCost: number;
+  reciprocity: string[];
+  certNumberFormat?: string;
+  bowhunterEdRequired: boolean;
+  trapperEdRequired: boolean;
+  sourceUrl: string;
+  notes?: string;
+}
+
+// Reciprocity is "yes by virtue of IHEA-USA cert mutual recognition" for most
+// states; the reciprocity[] array enumerates state codes whose certs are
+// explicitly named in the agency rules.
+const ALL_FIFTY_STATES_RECIPROCAL = [
+  "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA",
+  "KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+  "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT",
+  "VA","WA","WV","WI","WY",
+];
+
+const IHEA_ONLINE = (state: string): AcceptedCourse => ({
+  provider: "Hunter-Ed.com (IHEA-USA approved)",
+  format: "online",
+  cost: 24.95,
+  url: `https://www.hunter-ed.com/${state.toLowerCase()}/`,
+  notes: "Industry-standard online curriculum; final exam in-person or proctored.",
+});
+
+const SEEDS: HunterEdSeed[] = [
+  // ---------------------------------------------------------------------------
+  // WESTERN
+  // ---------------------------------------------------------------------------
+  {
+    stateCode: "CO",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1949,
+    minimumAge: 10,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 30,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    certNumberFormat: "alphanumeric, 8-10 chars",
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://cpw.state.co.us/learn/Pages/HunterEdRequirement.aspx",
+    acceptedCourses: [
+      IHEA_ONLINE("CO"),
+      {
+        provider: "Colorado Parks & Wildlife — In-Person",
+        format: "in_person",
+        cost: 10,
+        url: "https://cpw.state.co.us/learn/Pages/HunterEdClasses.aspx",
+      },
+    ],
+  },
+  {
+    stateCode: "WY",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1966,
+    minimumAge: 12,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 25,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://wgfd.wyo.gov/education/hunter-education",
+    acceptedCourses: [IHEA_ONLINE("WY")],
+  },
+  {
+    stateCode: "AZ",
+    requiredFor: "age_only",
+    minimumAge: 14,
+    apprenticeAllowed: true,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 24.95,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://www.azgfd.com/hunting/hunter-education/",
+    acceptedCourses: [IHEA_ONLINE("AZ")],
+  },
+  {
+    stateCode: "NV",
+    requiredFor: "all_first_time",
+    minimumAge: 12,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 2,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 24.95,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: true,
+    sourceUrl: "https://ndow.org/learn/education/hunter-education/",
+    acceptedCourses: [IHEA_ONLINE("NV")],
+  },
+  {
+    stateCode: "UT",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1965,
+    minimumAge: 9,
+    apprenticeAllowed: true,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 10,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://wildlife.utah.gov/learning/hunter-education.html",
+    acceptedCourses: [IHEA_ONLINE("UT")],
+  },
+  {
+    stateCode: "ID",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1975,
+    minimumAge: 9,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 2,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 8,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: true,
+    trapperEdRequired: true,
+    sourceUrl: "https://idfg.idaho.gov/education/hunter",
+    acceptedCourses: [IHEA_ONLINE("ID")],
+  },
+  {
+    stateCode: "OR",
+    requiredFor: "age_only",
+    minimumAge: 17,
+    apprenticeAllowed: true,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 19,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://myodfw.com/articles/hunter-education-overview",
+    acceptedCourses: [IHEA_ONLINE("OR")],
+  },
+  {
+    stateCode: "MT",
+    requiredFor: "all_first_time",
+    minimumAge: 10,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 10,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: true,
+    trapperEdRequired: false,
+    sourceUrl: "https://fwp.mt.gov/education/hunter",
+    acceptedCourses: [IHEA_ONLINE("MT")],
+  },
+  {
+    stateCode: "NM",
+    requiredFor: "age_only",
+    minimumAge: 18,
+    apprenticeAllowed: true,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 18,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://www.wildlife.state.nm.us/education/hunter-education/",
+    acceptedCourses: [IHEA_ONLINE("NM")],
+  },
+  {
+    stateCode: "WA",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1972,
+    minimumAge: 8,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 19,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://wdfw.wa.gov/licenses/hunting/hunter-education",
+    acceptedCourses: [IHEA_ONLINE("WA")],
+  },
+  {
+    stateCode: "AK",
+    requiredFor: "age_only",
+    minimumAge: 10,
+    apprenticeAllowed: true,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 20,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://www.adfg.alaska.gov/index.cfm?adfg=hunteredinfo.main",
+    acceptedCourses: [IHEA_ONLINE("AK")],
+    notes: "Only required for hunting on military lands or in some game management units.",
+  },
+  {
+    stateCode: "CA",
+    requiredFor: "all_first_time",
+    minimumAge: 12,
+    apprenticeAllowed: false,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 35,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: true,
+    sourceUrl: "https://wildlife.ca.gov/Hunter-Education",
+    acceptedCourses: [IHEA_ONLINE("CA")],
+  },
+
+  // ---------------------------------------------------------------------------
+  // EASTERN / SOUTHERN (priority states for new-hunter coverage)
+  // ---------------------------------------------------------------------------
+  {
+    stateCode: "GA",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1961,
+    minimumAge: 12,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 15,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://georgiawildlife.com/HunterEducation",
+    notes:
+      "Required for hunting on WMAs and for residents/non-residents born on or after Jan 1 1961. Apprentice license valid 1 year only.",
+    acceptedCourses: [
+      IHEA_ONLINE("GA"),
+      {
+        provider: "Today's Hunter (GA DNR)",
+        format: "online",
+        cost: 0,
+        url: "https://www.todayshunter.com/georgia/",
+        notes: "Free online course (study only — pass exam at in-person test site or via proctor).",
+      },
+    ],
+  },
+  {
+    stateCode: "PA",
+    requiredFor: "all_first_time",
+    minimumAge: 11,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 3,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 19.5,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: true,
+    sourceUrl: "https://www.pgc.pa.gov/Education/HunterTrapperEducation/Pages/default.aspx",
+    acceptedCourses: [IHEA_ONLINE("PA")],
+  },
+  {
+    stateCode: "TX",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1971,
+    minimumAge: 9,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 15,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://tpwd.texas.gov/education/hunter-education",
+    acceptedCourses: [IHEA_ONLINE("TX")],
+    notes: "Online-only option for adults; in-person/field day required for under-17.",
+  },
+  {
+    stateCode: "FL",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1972,
+    minimumAge: 0,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://myfwc.com/license/recreational/hunter-safety/",
+    acceptedCourses: [
+      IHEA_ONLINE("FL"),
+      {
+        provider: "FWC Hunter Safety (free)",
+        format: "online",
+        cost: 0,
+        url: "https://myfwc.com/license/recreational/hunter-safety/online-course/",
+      },
+    ],
+  },
+  {
+    stateCode: "NC",
+    requiredFor: "all_first_time",
+    minimumAge: 10,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: true,
+    sourceUrl: "https://www.ncwildlife.org/learning/hunter-education",
+    acceptedCourses: [IHEA_ONLINE("NC")],
+  },
+  {
+    stateCode: "NY",
+    requiredFor: "all_first_time",
+    minimumAge: 11,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: true,
+    trapperEdRequired: true,
+    sourceUrl: "https://www.dec.ny.gov/things-to-do/sportsman-education",
+    acceptedCourses: [IHEA_ONLINE("NY")],
+  },
+  {
+    stateCode: "OH",
+    requiredFor: "all_first_time",
+    minimumAge: 0,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 3,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 15,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: true,
+    sourceUrl: "https://ohiodnr.gov/discover-and-learn/safety-conservation/hunter-education",
+    acceptedCourses: [IHEA_ONLINE("OH")],
+  },
+  {
+    stateCode: "MI",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1960,
+    minimumAge: 10,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 3,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://www.michigan.gov/dnr/education-safety/hunter",
+    acceptedCourses: [IHEA_ONLINE("MI")],
+  },
+  {
+    stateCode: "VA",
+    requiredFor: "all_first_time",
+    minimumAge: 12,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://dwr.virginia.gov/hunting/education/",
+    acceptedCourses: [IHEA_ONLINE("VA")],
+  },
+  {
+    stateCode: "TN",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1969,
+    minimumAge: 9,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: true,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://www.tn.gov/twra/hunting/hunter-education.html",
+    acceptedCourses: [IHEA_ONLINE("TN")],
+  },
+  {
+    stateCode: "AL",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1977,
+    minimumAge: 10,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://www.outdooralabama.com/hunter-education",
+    acceptedCourses: [IHEA_ONLINE("AL")],
+  },
+  {
+    stateCode: "MS",
+    requiredFor: "born_on_or_after",
+    bornOnOrAfter: 1972,
+    minimumAge: 10,
+    apprenticeAllowed: true,
+    apprenticeMaxYears: 1,
+    onlineAllowed: true,
+    fieldDayRequired: false,
+    typicalCost: 0,
+    reciprocity: ALL_FIFTY_STATES_RECIPROCAL,
+    bowhunterEdRequired: false,
+    trapperEdRequired: false,
+    sourceUrl: "https://www.mdwfp.com/wildlife-hunting/hunter-education/",
+    acceptedCourses: [IHEA_ONLINE("MS")],
+  },
+];
+
+async function upsertHunterEd(seed: HunterEdSeed): Promise<void> {
+  // Look up state by code
+  const [state] = await db
+    .select()
+    .from(states)
+    .where(eq(states.code, seed.stateCode))
+    .limit(1);
+
+  if (!state) {
+    console.log(`  ! State not found in DB: ${seed.stateCode} — skipping`);
+    return;
+  }
+
+  const existing = await db
+    .select()
+    .from(hunterEducationRequirements)
+    .where(eq(hunterEducationRequirements.stateId, state.id))
+    .limit(1);
+
+  const row = {
+    stateId: state.id,
+    requiredFor: seed.requiredFor,
+    bornOnOrAfter: seed.bornOnOrAfter ?? null,
+    minimumAge: seed.minimumAge ?? null,
+    apprenticeAllowed: seed.apprenticeAllowed,
+    apprenticeMaxYears: seed.apprenticeMaxYears ?? null,
+    acceptedCourses: seed.acceptedCourses,
+    onlineAllowed: seed.onlineAllowed,
+    fieldDayRequired: seed.fieldDayRequired,
+    typicalCost: seed.typicalCost,
+    reciprocity: seed.reciprocity,
+    certNumberFormat: seed.certNumberFormat ?? null,
+    bowhunterEdRequired: seed.bowhunterEdRequired,
+    trapperEdRequired: seed.trapperEdRequired,
+    sourceUrl: seed.sourceUrl,
+    notes: seed.notes ?? null,
+    lastVerified: new Date(),
+    updatedAt: new Date(),
+  };
+
+  if (existing.length > 0) {
+    await db
+      .update(hunterEducationRequirements)
+      .set(row)
+      .where(eq(hunterEducationRequirements.id, existing[0]!.id));
+    console.log(`  ✓ Updated: ${seed.stateCode}`);
+  } else {
+    await db.insert(hunterEducationRequirements).values(row);
+    console.log(`  + Created: ${seed.stateCode}`);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log("Seeding hunter education requirements...");
+  console.log("");
+  for (const seed of SEEDS) {
+    try {
+      await upsertHunterEd(seed);
+    } catch (error) {
+      console.error(`  ✗ ${seed.stateCode}: ${error}`);
+    }
+  }
+  console.log("");
+  console.log(`Done. ${SEEDS.length} states seeded.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/seed-license-types-core.ts
+++ b/scripts/seed-license-types-core.ts
@@ -1,0 +1,580 @@
+/**
+ * Seed: License Types — Core priority states
+ *
+ * Populates `license_types` with the canonical hunting licenses + species
+ * tags for each priority state. Values are nominal 2026 retail prices from
+ * each agency's published fee schedules; ops should re-verify annually.
+ *
+ * Covers:
+ *  - Western: CO, WY, AZ, NV, UT, ID, OR, MT, NM, WA
+ *  - Eastern/Southern: GA, PA, TX, FL, NC, NY, OH, MI, VA, TN, AL, MS
+ *
+ * Within each state we seed:
+ *  - Base hunting license (resident + nonresident)
+ *  - Big-game species tags (deer, elk, turkey, bear where applicable)
+ *  - Common stamps (federal waterfowl, state habitat stamp)
+ *  - Youth + senior variants where the agency publishes a discount
+ *  - Apprentice / sportsman combos where they exist
+ *
+ * The structure is deliberately verbose — each row is one row in license_types,
+ * making downstream querying ("show me every license a CO resident needs to
+ * hunt elk") a clean WHERE filter.
+ *
+ * Run: pnpm tsx scripts/seed-license-types-core.ts
+ */
+
+import { db } from "../src/lib/db";
+import { states, species, licenseTypes } from "../src/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+
+interface LicenseSeed {
+  stateCode: string;
+  speciesSlug?: string | null;
+  licenseCode: string;
+  name: string;
+  description: string;
+  residency: "resident" | "nonresident" | "all";
+  cost: number;
+  minAge?: number;
+  maxAge?: number;
+  validFrom?: string;
+  validTo?: string;
+  prerequisites?: Record<string, unknown>;
+  isOtc?: boolean;
+  isDrawEntry?: boolean;
+  quantityLimit?: number;
+  sourceUrl: string;
+  year: number;
+}
+
+const YEAR = 2026;
+
+const SEEDS: LicenseSeed[] = [
+  // ===========================================================================
+  // COLORADO
+  // ===========================================================================
+  {
+    stateCode: "CO", licenseCode: "small_game_license", name: "Annual Small Game License",
+    description: "Required to hunt small game and to purchase big-game tags.",
+    residency: "resident", cost: 30.87, isOtc: true, year: YEAR,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/HuntingLicenses.aspx",
+  },
+  {
+    stateCode: "CO", licenseCode: "small_game_license", name: "Annual Small Game License",
+    description: "Required to hunt small game and to purchase big-game tags.",
+    residency: "nonresident", cost: 91.94, isOtc: true, year: YEAR,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/HuntingLicenses.aspx",
+  },
+  {
+    stateCode: "CO", speciesSlug: "elk", licenseCode: "elk_tag_otc",
+    name: "Elk OTC Either-Sex Tag (specific units)",
+    description: "Over-the-counter elk tag valid in designated OTC units.",
+    residency: "resident", cost: 60.32, isOtc: true, year: YEAR,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/HuntingLicenses.aspx",
+  },
+  {
+    stateCode: "CO", speciesSlug: "elk", licenseCode: "elk_tag_otc",
+    name: "Elk OTC Either-Sex Tag (specific units)",
+    description: "Over-the-counter elk tag valid in designated OTC units.",
+    residency: "nonresident", cost: 791.59, isOtc: true, year: YEAR,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/HuntingLicenses.aspx",
+  },
+  {
+    stateCode: "CO", speciesSlug: "mule_deer", licenseCode: "deer_tag_draw",
+    name: "Deer License (Draw)",
+    description: "Limited-entry deer tag awarded via the spring big-game draw.",
+    residency: "resident", cost: 45.65, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/HuntingLicenses.aspx",
+  },
+  {
+    stateCode: "CO", speciesSlug: "mule_deer", licenseCode: "deer_tag_draw",
+    name: "Deer License (Draw)",
+    description: "Limited-entry deer tag awarded via the spring big-game draw.",
+    residency: "nonresident", cost: 478.50, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/HuntingLicenses.aspx",
+  },
+  {
+    stateCode: "CO", licenseCode: "habitat_stamp", name: "Habitat Stamp",
+    description: "Required for all hunters and anglers age 18-64. Funds habitat conservation.",
+    residency: "all", cost: 10.94, isOtc: true, year: YEAR, minAge: 18, maxAge: 64,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/HabitatStamp.aspx",
+  },
+  {
+    stateCode: "CO", licenseCode: "preference_point", name: "Big Game Preference Point",
+    description: "Build preference points for future big-game draws.",
+    residency: "all", cost: 47, isOtc: true, year: YEAR,
+    sourceUrl: "https://cpw.state.co.us/buyapply/Pages/PreferencePoints.aspx",
+    prerequisites: { hunter_ed: true },
+  },
+
+  // ===========================================================================
+  // WYOMING
+  // ===========================================================================
+  {
+    stateCode: "WY", licenseCode: "conservation_stamp", name: "Conservation Stamp",
+    description: "Required for all hunters and anglers 14+ purchasing any license.",
+    residency: "all", cost: 21.50, isOtc: true, year: YEAR, minAge: 14,
+    sourceUrl: "https://wgfd.wyo.gov/get-involved/buy-a-license",
+  },
+  {
+    stateCode: "WY", speciesSlug: "elk", licenseCode: "elk_license_draw",
+    name: "Elk License (Draw)",
+    description: "Limited-entry elk license awarded via draw. Separate resident/nonresident pools.",
+    residency: "resident", cost: 57, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://wgfd.wyo.gov/get-involved/applications-and-draws",
+  },
+  {
+    stateCode: "WY", speciesSlug: "elk", licenseCode: "elk_license_draw",
+    name: "Elk License (Draw)",
+    description: "Limited-entry elk license awarded via draw. Separate resident/nonresident pools.",
+    residency: "nonresident", cost: 707, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://wgfd.wyo.gov/get-involved/applications-and-draws",
+  },
+  {
+    stateCode: "WY", speciesSlug: "pronghorn", licenseCode: "pronghorn_license_draw",
+    name: "Pronghorn (Antelope) License (Draw)",
+    description: "Limited-entry pronghorn tag. Strong nonresident odds in many units.",
+    residency: "resident", cost: 35, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://wgfd.wyo.gov/get-involved/applications-and-draws",
+  },
+  {
+    stateCode: "WY", speciesSlug: "pronghorn", licenseCode: "pronghorn_license_draw",
+    name: "Pronghorn (Antelope) License (Draw)",
+    description: "Limited-entry pronghorn tag. Strong nonresident odds in many units.",
+    residency: "nonresident", cost: 363, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://wgfd.wyo.gov/get-involved/applications-and-draws",
+  },
+
+  // ===========================================================================
+  // ARIZONA
+  // ===========================================================================
+  {
+    stateCode: "AZ", licenseCode: "general_license", name: "General Hunting License",
+    description: "Required for all hunters and to purchase big-game tags.",
+    residency: "resident", cost: 37, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.azgfd.com/license/hunting/",
+  },
+  {
+    stateCode: "AZ", licenseCode: "general_license", name: "General Hunting License",
+    description: "Required for all hunters and to purchase big-game tags.",
+    residency: "nonresident", cost: 160, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.azgfd.com/license/hunting/",
+  },
+  {
+    stateCode: "AZ", speciesSlug: "elk", licenseCode: "elk_tag_draw",
+    name: "Elk Hunt Permit-Tag (Draw)",
+    description: "Awarded via spring draw. 10% nonresident quota in most hunts.",
+    residency: "resident", cost: 138, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://www.azgfd.com/hunting/draw/",
+  },
+  {
+    stateCode: "AZ", speciesSlug: "elk", licenseCode: "elk_tag_draw",
+    name: "Elk Hunt Permit-Tag (Draw)",
+    description: "Awarded via spring draw. 10% nonresident quota in most hunts.",
+    residency: "nonresident", cost: 685, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://www.azgfd.com/hunting/draw/",
+  },
+  {
+    stateCode: "AZ", licenseCode: "bonus_point", name: "Bonus Point (per species)",
+    description: "Build bonus points for future draws. Earned by applying.",
+    residency: "all", cost: 15, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.azgfd.com/hunting/draw/",
+  },
+
+  // ===========================================================================
+  // NEVADA
+  // ===========================================================================
+  {
+    stateCode: "NV", licenseCode: "hunting_license", name: "Hunting License",
+    description: "Required to hunt and to apply for tag draws.",
+    residency: "resident", cost: 38, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.ndow.org/Hunt/Licensing/",
+  },
+  {
+    stateCode: "NV", licenseCode: "hunting_license", name: "Hunting License",
+    description: "Required to hunt and to apply for tag draws.",
+    residency: "nonresident", cost: 155, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.ndow.org/Hunt/Licensing/",
+  },
+  {
+    stateCode: "NV", speciesSlug: "elk", licenseCode: "elk_tag_draw",
+    name: "Elk Tag (Draw)",
+    description: "Limited-entry elk tag. Bonus² point system.",
+    residency: "resident", cost: 120, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://www.ndow.org/Hunt/Tags/Draw/",
+  },
+  {
+    stateCode: "NV", speciesSlug: "elk", licenseCode: "elk_tag_draw",
+    name: "Elk Tag (Draw)",
+    description: "Limited-entry elk tag. Bonus² point system.",
+    residency: "nonresident", cost: 1200, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://www.ndow.org/Hunt/Tags/Draw/",
+  },
+
+  // ===========================================================================
+  // UTAH
+  // ===========================================================================
+  {
+    stateCode: "UT", licenseCode: "combination_license", name: "Combination Hunting+Fishing License",
+    description: "Annual hunting/fishing combination license. Required to hunt or fish.",
+    residency: "resident", cost: 38, isOtc: true, year: YEAR,
+    sourceUrl: "https://wildlife.utah.gov/license.html",
+  },
+  {
+    stateCode: "UT", licenseCode: "combination_license", name: "Combination Hunting+Fishing License",
+    description: "Annual hunting/fishing combination license.",
+    residency: "nonresident", cost: 144, isOtc: true, year: YEAR,
+    sourceUrl: "https://wildlife.utah.gov/license.html",
+  },
+  {
+    stateCode: "UT", speciesSlug: "mule_deer", licenseCode: "general_deer_permit",
+    name: "General Deer Permit (Draw)",
+    description: "Limited-entry deer permit by region (Northern/Central/Southeastern/Southern).",
+    residency: "resident", cost: 50, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://wildlife.utah.gov/hunting/big-game.html",
+  },
+  {
+    stateCode: "UT", speciesSlug: "mule_deer", licenseCode: "general_deer_permit",
+    name: "General Deer Permit (Draw)",
+    description: "Limited-entry deer permit by region.",
+    residency: "nonresident", cost: 412, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://wildlife.utah.gov/hunting/big-game.html",
+  },
+
+  // ===========================================================================
+  // IDAHO
+  // ===========================================================================
+  {
+    stateCode: "ID", licenseCode: "hunting_license", name: "Hunting License",
+    description: "Required to hunt and to apply for controlled hunt tags.",
+    residency: "resident", cost: 19.75, isOtc: true, year: YEAR,
+    sourceUrl: "https://idfg.idaho.gov/licenses",
+  },
+  {
+    stateCode: "ID", licenseCode: "hunting_license", name: "Hunting License",
+    description: "Required to hunt and to apply for controlled hunt tags.",
+    residency: "nonresident", cost: 185, isOtc: true, year: YEAR,
+    sourceUrl: "https://idfg.idaho.gov/licenses",
+  },
+  {
+    stateCode: "ID", speciesSlug: "elk", licenseCode: "elk_tag_general",
+    name: "General Elk Tag",
+    description: "Most ID elk tags are OTC general-season; some controlled hunts.",
+    residency: "resident", cost: 30.75, isOtc: true, year: YEAR,
+    sourceUrl: "https://idfg.idaho.gov/hunt/elk",
+  },
+  {
+    stateCode: "ID", speciesSlug: "elk", licenseCode: "elk_tag_general",
+    name: "General Elk Tag",
+    description: "Most ID elk tags are OTC general-season; some controlled hunts.",
+    residency: "nonresident", cost: 651.75, isOtc: true, year: YEAR,
+    sourceUrl: "https://idfg.idaho.gov/hunt/elk",
+  },
+
+  // ===========================================================================
+  // GEORGIA — specifically chosen because Mitch called it out for the
+  // "shotgun in GA → what can I hunt" use case.
+  // ===========================================================================
+  {
+    stateCode: "GA", licenseCode: "hunting_license", name: "Resident Hunting License",
+    description: "Required for all resident hunters age 16+.",
+    residency: "resident", cost: 15, isOtc: true, year: YEAR, minAge: 16,
+    sourceUrl: "https://georgiawildlife.com/licenses-permits-passes",
+  },
+  {
+    stateCode: "GA", licenseCode: "hunting_license", name: "Nonresident Hunting License",
+    description: "Required for all nonresident hunters age 16+.",
+    residency: "nonresident", cost: 100, isOtc: true, year: YEAR, minAge: 16,
+    sourceUrl: "https://georgiawildlife.com/licenses-permits-passes",
+  },
+  {
+    stateCode: "GA", licenseCode: "sportsman_license", name: "Sportsman License",
+    description: "Combo license: hunting + fishing + big-game + WMA + waterfowl. Best value for active GA hunters.",
+    residency: "resident", cost: 65, isOtc: true, year: YEAR,
+    sourceUrl: "https://georgiawildlife.com/licenses-permits-passes",
+  },
+  {
+    stateCode: "GA", speciesSlug: "whitetail_deer", licenseCode: "big_game_license",
+    name: "Big Game License (incl. with Sportsman)",
+    description: "Required to hunt deer, bear, or turkey. Bundled in Sportsman.",
+    residency: "resident", cost: 25, isOtc: true, year: YEAR,
+    sourceUrl: "https://georgiawildlife.com/licenses-permits-passes",
+  },
+  {
+    stateCode: "GA", speciesSlug: "whitetail_deer", licenseCode: "big_game_license",
+    name: "Big Game License (incl. with Sportsman)",
+    description: "Required to hunt deer, bear, or turkey.",
+    residency: "nonresident", cost: 225, isOtc: true, year: YEAR,
+    sourceUrl: "https://georgiawildlife.com/licenses-permits-passes",
+  },
+  {
+    stateCode: "GA", licenseCode: "wma_license", name: "WMA License",
+    description: "Required to hunt or fish on Wildlife Management Areas. Included with Sportsman license.",
+    residency: "all", cost: 30, isOtc: true, year: YEAR,
+    sourceUrl: "https://georgiawildlife.com/licenses-permits-passes",
+  },
+  {
+    stateCode: "GA", speciesSlug: "wild_turkey", licenseCode: "turkey_license",
+    name: "Turkey License (incl. with Sportsman)",
+    description: "Required to hunt turkey. 2-tag annual limit. Bundled in Sportsman.",
+    residency: "resident", cost: 0, isOtc: true, year: YEAR, quantityLimit: 2,
+    sourceUrl: "https://georgiawildlife.com/turkey",
+  },
+  {
+    stateCode: "GA", licenseCode: "waterfowl_stamp", name: "Federal Migratory Bird Stamp (Duck Stamp)",
+    description: "Required for waterfowl hunting nationwide. Federal stamp.",
+    residency: "all", cost: 25, isOtc: true, year: YEAR,
+    sourceUrl: "https://georgiawildlife.com/waterfowl",
+  },
+  {
+    stateCode: "GA", licenseCode: "ga_waterfowl_license", name: "Georgia Waterfowl License",
+    description: "Required for state waterfowl hunting (in addition to federal duck stamp).",
+    residency: "resident", cost: 10, isOtc: true, year: YEAR,
+    sourceUrl: "https://georgiawildlife.com/waterfowl",
+  },
+
+  // ===========================================================================
+  // PENNSYLVANIA
+  // ===========================================================================
+  {
+    stateCode: "PA", licenseCode: "general_license", name: "General Hunting License",
+    description: "Required for all hunters age 12+.",
+    residency: "resident", cost: 20.97, isOtc: true, year: YEAR, minAge: 12,
+    sourceUrl: "https://www.pgc.pa.gov/HuntTrap/HuntingLicenses/Pages/default.aspx",
+  },
+  {
+    stateCode: "PA", licenseCode: "general_license", name: "General Hunting License",
+    description: "Required for all hunters age 12+.",
+    residency: "nonresident", cost: 101.97, isOtc: true, year: YEAR, minAge: 12,
+    sourceUrl: "https://www.pgc.pa.gov/HuntTrap/HuntingLicenses/Pages/default.aspx",
+  },
+  {
+    stateCode: "PA", speciesSlug: "elk", licenseCode: "elk_license_draw",
+    name: "Elk License (Draw)",
+    description: "Rare draw-only elk tag for PA's growing herd.",
+    residency: "resident", cost: 41.97, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://www.pgc.pa.gov/HuntTrap/Elk/Pages/default.aspx",
+  },
+  {
+    stateCode: "PA", speciesSlug: "whitetail_deer", licenseCode: "antlerless_deer",
+    name: "Antlerless Deer License",
+    description: "Required for doe harvest. Allocated by WMU.",
+    residency: "resident", cost: 6.97, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://www.pgc.pa.gov/HuntTrap/Antlerless/Pages/default.aspx",
+  },
+
+  // ===========================================================================
+  // TEXAS
+  // ===========================================================================
+  {
+    stateCode: "TX", licenseCode: "annual_hunting_license", name: "Resident Annual Hunting License",
+    description: "Required for all Texas hunters age 17+.",
+    residency: "resident", cost: 25, isOtc: true, year: YEAR, minAge: 17,
+    sourceUrl: "https://tpwd.texas.gov/regulations/outdoor-annual/licenses",
+  },
+  {
+    stateCode: "TX", licenseCode: "annual_hunting_license", name: "Nonresident General Hunting License",
+    description: "Required for nonresident hunters.",
+    residency: "nonresident", cost: 315, isOtc: true, year: YEAR, minAge: 17,
+    sourceUrl: "https://tpwd.texas.gov/regulations/outdoor-annual/licenses",
+  },
+  {
+    stateCode: "TX", licenseCode: "super_combo", name: "Super Combo License Package",
+    description: "Bundles hunting, fishing, archery, migratory bird, and all stamps. Best value.",
+    residency: "resident", cost: 68, isOtc: true, year: YEAR,
+    sourceUrl: "https://tpwd.texas.gov/regulations/outdoor-annual/licenses",
+  },
+  {
+    stateCode: "TX", licenseCode: "upland_stamp", name: "Upland Game Bird Stamp",
+    description: "Required for quail, pheasant, chachalaca hunting.",
+    residency: "all", cost: 7, isOtc: true, year: YEAR,
+    sourceUrl: "https://tpwd.texas.gov/regulations/outdoor-annual/licenses",
+  },
+
+  // ===========================================================================
+  // FLORIDA
+  // ===========================================================================
+  {
+    stateCode: "FL", licenseCode: "hunting_license", name: "Hunting License",
+    description: "Annual license. Required for ages 16+.",
+    residency: "resident", cost: 17, isOtc: true, year: YEAR, minAge: 16,
+    sourceUrl: "https://myfwc.com/license/recreational/",
+  },
+  {
+    stateCode: "FL", licenseCode: "hunting_license", name: "Hunting License",
+    description: "Annual license for nonresident.",
+    residency: "nonresident", cost: 151.50, isOtc: true, year: YEAR, minAge: 16,
+    sourceUrl: "https://myfwc.com/license/recreational/",
+  },
+  {
+    stateCode: "FL", licenseCode: "wma_permit", name: "Wildlife Management Area Permit",
+    description: "Required for hunting on FL WMAs.",
+    residency: "all", cost: 26.50, isOtc: true, year: YEAR,
+    sourceUrl: "https://myfwc.com/license/recreational/",
+  },
+  {
+    stateCode: "FL", licenseCode: "deer_permit", name: "Deer Permit",
+    description: "Required for deer hunting.",
+    residency: "all", cost: 5, isOtc: true, year: YEAR,
+    sourceUrl: "https://myfwc.com/hunting/deer/",
+  },
+  {
+    stateCode: "FL", speciesSlug: "wild_turkey", licenseCode: "turkey_permit",
+    name: "Turkey Permit",
+    description: "Required for turkey hunting. Annual.",
+    residency: "all", cost: 10, isOtc: true, year: YEAR,
+    sourceUrl: "https://myfwc.com/hunting/turkey/",
+  },
+
+  // ===========================================================================
+  // NORTH CAROLINA
+  // ===========================================================================
+  {
+    stateCode: "NC", licenseCode: "sportsman", name: "Sportsman License (Combo)",
+    description: "Hunting + fishing + big-game + bear + game lands.",
+    residency: "resident", cost: 40, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.ncwildlife.org/Licenses-Permits",
+  },
+  {
+    stateCode: "NC", licenseCode: "annual_hunting", name: "Annual Hunting License",
+    description: "Basic hunting license.",
+    residency: "resident", cost: 25, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.ncwildlife.org/Licenses-Permits",
+  },
+  {
+    stateCode: "NC", licenseCode: "annual_hunting", name: "Annual Hunting License",
+    description: "Basic hunting license — nonresident.",
+    residency: "nonresident", cost: 100, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.ncwildlife.org/Licenses-Permits",
+  },
+  {
+    stateCode: "NC", speciesSlug: "whitetail_deer", licenseCode: "big_game_privilege",
+    name: "Big Game Hunting Privilege",
+    description: "Required in addition to base license for deer/bear/turkey.",
+    residency: "resident", cost: 15, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.ncwildlife.org/Licenses-Permits",
+  },
+
+  // ===========================================================================
+  // NEW YORK
+  // ===========================================================================
+  {
+    stateCode: "NY", licenseCode: "small_game", name: "Small Game License",
+    description: "Required for all hunters. Annual.",
+    residency: "resident", cost: 22, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.dec.ny.gov/things-to-do/licenses",
+  },
+  {
+    stateCode: "NY", speciesSlug: "whitetail_deer", licenseCode: "big_game_license",
+    name: "Big Game License",
+    description: "Required for deer or bear. Includes 1 buck tag.",
+    residency: "resident", cost: 25, isOtc: true, year: YEAR,
+    sourceUrl: "https://www.dec.ny.gov/things-to-do/licenses",
+  },
+  {
+    stateCode: "NY", speciesSlug: "whitetail_deer", licenseCode: "doe_permit",
+    name: "Deer Management Permit (DMP)",
+    description: "Antlerless deer permit allocated by WMU via random selection.",
+    residency: "all", cost: 10, isDrawEntry: true, year: YEAR,
+    sourceUrl: "https://www.dec.ny.gov/outdoor/deer",
+  },
+];
+
+async function upsertLicense(seed: LicenseSeed): Promise<void> {
+  const [state] = await db
+    .select()
+    .from(states)
+    .where(eq(states.code, seed.stateCode))
+    .limit(1);
+  if (!state) {
+    console.log(`  ! State not found in DB: ${seed.stateCode} — skipping`);
+    return;
+  }
+
+  let speciesId: string | null = null;
+  if (seed.speciesSlug) {
+    const [sp] = await db
+      .select()
+      .from(species)
+      .where(eq(species.slug, seed.speciesSlug))
+      .limit(1);
+    if (!sp) {
+      console.log(
+        `  ! Species not in DB: ${seed.speciesSlug} (state ${seed.stateCode}) — inserting license without species link`
+      );
+    } else {
+      speciesId = sp.id;
+    }
+  }
+
+  // Composite key: (state, species, licenseCode, residency, year)
+  const existing = await db
+    .select()
+    .from(licenseTypes)
+    .where(
+      and(
+        eq(licenseTypes.stateId, state.id),
+        eq(licenseTypes.licenseCode, seed.licenseCode),
+        eq(licenseTypes.residency, seed.residency),
+        eq(licenseTypes.year, seed.year)
+      )
+    )
+    .limit(1);
+
+  const row = {
+    stateId: state.id,
+    speciesId,
+    licenseCode: seed.licenseCode,
+    name: seed.name,
+    description: seed.description,
+    residency: seed.residency,
+    cost: seed.cost,
+    minAge: seed.minAge ?? null,
+    maxAge: seed.maxAge ?? null,
+    validFrom: seed.validFrom ?? null,
+    validTo: seed.validTo ?? null,
+    prerequisites: seed.prerequisites ?? {},
+    isOtc: seed.isOtc ?? false,
+    isDrawEntry: seed.isDrawEntry ?? false,
+    quantityLimit: seed.quantityLimit ?? null,
+    sourceUrl: seed.sourceUrl,
+    year: seed.year,
+    lastVerified: new Date(),
+    enabled: true,
+  };
+
+  if (existing.length > 0) {
+    await db
+      .update(licenseTypes)
+      .set(row)
+      .where(eq(licenseTypes.id, existing[0]!.id));
+  } else {
+    await db.insert(licenseTypes).values(row);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`Seeding ${SEEDS.length} license-type rows...`);
+  console.log("");
+  let ok = 0;
+  let fail = 0;
+  for (const seed of SEEDS) {
+    try {
+      await upsertLicense(seed);
+      ok++;
+    } catch (error) {
+      fail++;
+      console.error(
+        `  ✗ ${seed.stateCode}/${seed.licenseCode} (${seed.residency}): ${error}`
+      );
+    }
+  }
+  console.log("");
+  console.log(`Done. ${ok} seeded, ${fail} failed.`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/seed-weapon-regulations.ts
+++ b/scripts/seed-weapon-regulations.ts
@@ -1,0 +1,370 @@
+/**
+ * Seed: Weapon Regulations — priority states + species
+ *
+ * Encodes the legal weapon rules per (state, species, weapon, season). Powers
+ * the equipment-aware concierge: "Georgia + shotgun + deer → here's what's
+ * legal where, with these restrictions, in these seasons."
+ *
+ * Notes on the schema:
+ *   - `allowed=false` rows ARE valuable. They let the concierge say
+ *     "you cannot use a rifle for deer in this GA county" instead of
+ *     hallucinating.
+ *   - `restrictions` JSONB carries the granular rules (min_caliber, gauge,
+ *     broadhead, magazine_capacity, etc).
+ *   - `hunt_unit_overrides` carries county/zone allowlists/denylists.
+ *   - `summary` is a human-readable line cited verbatim by the concierge.
+ *
+ * Run: pnpm tsx scripts/seed-weapon-regulations.ts
+ */
+
+import { db } from "../src/lib/db";
+import { states, species, weaponRegulations } from "../src/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+
+interface WeaponSeed {
+  stateCode: string;
+  speciesSlug: string;
+  weaponType: string;
+  allowed: boolean;
+  seasonContext?: string;
+  restrictions?: Record<string, unknown>;
+  huntUnitOverrides?: Record<string, unknown>;
+  summary: string;
+  sourceUrl: string;
+  year: number;
+}
+
+const YEAR = 2026;
+
+const SEEDS: WeaponSeed[] = [
+  // ===========================================================================
+  // GEORGIA — the headline "shotgun + deer" use case.
+  // GA has firearms-only / archery-only / primitive-weapon seasons and
+  // some shotgun-only counties (mostly in central/coastal GA where rifle
+  // is restricted due to flat terrain and population density).
+  // ===========================================================================
+  {
+    stateCode: "GA", speciesSlug: "whitetail_deer", weaponType: "rifle",
+    allowed: true, seasonContext: "firearms_season",
+    restrictions: {
+      min_caliber: ".22 centerfire",
+      sub_caliber_22_long_rifle_prohibited: true,
+      magazine_capacity_max: 5,
+      tracer_allowed: false,
+    },
+    huntUnitOverrides: {
+      // Some central + coastal GA counties are shotgun-only by ordinance.
+      // Examples: Bryan, Camden, Chatham, Glynn, Liberty, McIntosh.
+      deny_unit_codes: ["BRYAN", "CAMDEN", "CHATHAM", "GLYNN", "LIBERTY", "MCINTOSH"],
+      notes: "Rifle prohibited in coastal/central shotgun-only counties — confirm county-by-county.",
+    },
+    summary:
+      "Rifle legal for deer in firearms season statewide except shotgun-only counties (largely coastal). " +
+      "Center-fire only, no .22 long rifle, magazine capacity ≤ 5.",
+    sourceUrl: "https://georgiawildlife.com/regulations/hunting",
+    year: YEAR,
+  },
+  {
+    stateCode: "GA", speciesSlug: "whitetail_deer", weaponType: "shotgun_slug",
+    allowed: true, seasonContext: "firearms_season",
+    restrictions: {
+      min_gauge: 20,
+      slug_or_buckshot_allowed: ["slug", "00_buckshot_or_larger"],
+      magazine_capacity_max: 5,
+    },
+    summary:
+      "Shotgun (20 ga. or larger) loaded with slug or 00-buckshot-or-larger is legal for deer statewide. " +
+      "Required in shotgun-only counties.",
+    sourceUrl: "https://georgiawildlife.com/regulations/hunting",
+    year: YEAR,
+  },
+  {
+    stateCode: "GA", speciesSlug: "whitetail_deer", weaponType: "archery",
+    allowed: true, seasonContext: "archery_season",
+    restrictions: {
+      min_draw_weight_lbs: 35,
+      broadhead_min_blade_width_inches: 7 / 8,
+      mechanical_broadheads_allowed: true,
+    },
+    summary:
+      "Archery legal during archery season (mid-September on). Min 35 lb draw, broadhead ≥ 7/8 in.",
+    sourceUrl: "https://georgiawildlife.com/regulations/hunting",
+    year: YEAR,
+  },
+  {
+    stateCode: "GA", speciesSlug: "whitetail_deer", weaponType: "crossbow",
+    allowed: true, seasonContext: "archery_season",
+    restrictions: { min_draw_weight_lbs: 100, broadhead_required: true },
+    summary: "Crossbow legal during archery and firearms seasons for all hunters (no disability requirement).",
+    sourceUrl: "https://georgiawildlife.com/regulations/hunting",
+    year: YEAR,
+  },
+  {
+    stateCode: "GA", speciesSlug: "whitetail_deer", weaponType: "muzzleloader",
+    allowed: true, seasonContext: "primitive_weapons_season",
+    restrictions: { min_caliber: ".44", scope_allowed: true },
+    summary: "Muzzleloader (≥.44 cal) legal during primitive weapons + firearms seasons. Scopes allowed.",
+    sourceUrl: "https://georgiawildlife.com/regulations/hunting",
+    year: YEAR,
+  },
+  {
+    stateCode: "GA", speciesSlug: "wild_turkey", weaponType: "shotgun",
+    allowed: true, seasonContext: "spring_turkey_season",
+    restrictions: {
+      max_shot_size: "no_2_or_smaller",
+      ttss_shot_allowed: true,
+      max_gauge: 10,
+      magazine_capacity_max: 3,
+    },
+    summary:
+      "Shotgun legal for turkey, ≤ 10 ga., shot size #2 or smaller (incl. tungsten alternatives). " +
+      "Magazine ≤ 3 shells.",
+    sourceUrl: "https://georgiawildlife.com/turkey",
+    year: YEAR,
+  },
+  {
+    stateCode: "GA", speciesSlug: "wild_turkey", weaponType: "rifle",
+    allowed: false, seasonContext: "spring_turkey_season",
+    summary: "Rifles are NOT legal for spring turkey in Georgia.",
+    sourceUrl: "https://georgiawildlife.com/turkey",
+    year: YEAR,
+  },
+  {
+    stateCode: "GA", speciesSlug: "wild_turkey", weaponType: "archery",
+    allowed: true, seasonContext: "spring_turkey_season",
+    restrictions: { min_draw_weight_lbs: 35, broadhead_required: true },
+    summary: "Archery legal for spring turkey. Same equipment rules as deer.",
+    sourceUrl: "https://georgiawildlife.com/turkey",
+    year: YEAR,
+  },
+
+  // ===========================================================================
+  // COLORADO — sample big-game weapon rules
+  // ===========================================================================
+  {
+    stateCode: "CO", speciesSlug: "elk", weaponType: "rifle",
+    allowed: true, seasonContext: "rifle_season",
+    restrictions: {
+      min_caliber_centerfire: ".24",
+      min_bullet_energy_ftlbs_1000yd: 1000,
+      magazine_capacity_max: null,
+    },
+    summary:
+      "Center-fire rifle ≥ .24 cal, ≥1000 ft-lbs at 100 yd. Rifle seasons run late Oct–early Nov.",
+    sourceUrl: "https://cpw.state.co.us/thingstodo/Pages/Hunting.aspx",
+    year: YEAR,
+  },
+  {
+    stateCode: "CO", speciesSlug: "elk", weaponType: "muzzleloader",
+    allowed: true, seasonContext: "muzzleloader_season",
+    restrictions: {
+      min_caliber: ".50",
+      open_sights_only: true,
+      single_shot_only: true,
+      no_sabots: false,
+    },
+    summary:
+      "Muzzleloader ≥ .50 cal, single-shot, open sights only (no scopes). Mid-September.",
+    sourceUrl: "https://cpw.state.co.us/thingstodo/Pages/Hunting.aspx",
+    year: YEAR,
+  },
+  {
+    stateCode: "CO", speciesSlug: "elk", weaponType: "archery",
+    allowed: true, seasonContext: "archery_season",
+    restrictions: {
+      min_draw_weight_lbs: 35,
+      broadhead_min_blade_width_inches: 7 / 8,
+      no_electronic_aids: true,
+    },
+    summary: "Archery legal Sept 2 – Sept 30. ≥35# draw, ≥7/8 in. broadhead, no electronic aids.",
+    sourceUrl: "https://cpw.state.co.us/thingstodo/Pages/Hunting.aspx",
+    year: YEAR,
+  },
+
+  // ===========================================================================
+  // WYOMING — sample
+  // ===========================================================================
+  {
+    stateCode: "WY", speciesSlug: "elk", weaponType: "rifle",
+    allowed: true, seasonContext: "general_season",
+    restrictions: { min_caliber_centerfire: ".22 with 60-grain bullet" },
+    summary: "Center-fire rifle for elk, mid-Sept–mid-Oct typical, region-dependent.",
+    sourceUrl: "https://wgfd.wyo.gov/hunting/elk",
+    year: YEAR,
+  },
+
+  // ===========================================================================
+  // TEXAS — shotgun-only for deer in some counties (special "Type II")
+  // ===========================================================================
+  {
+    stateCode: "TX", speciesSlug: "whitetail_deer", weaponType: "rifle",
+    allowed: true, seasonContext: "general_season",
+    huntUnitOverrides: {
+      deny_unit_codes: ["COLLIN", "DALLAS", "DENTON", "GRAYSON", "ROCKWALL", "ELLIS"],
+      notes: "Shotgun/archery only in densely populated DFW-metro counties.",
+    },
+    summary: "Rifle legal statewide except shotgun-only DFW-metro counties.",
+    sourceUrl: "https://tpwd.texas.gov/regulations/outdoor-annual/hunting/general-rules",
+    year: YEAR,
+  },
+  {
+    stateCode: "TX", speciesSlug: "whitetail_deer", weaponType: "shotgun_slug",
+    allowed: true, seasonContext: "general_season",
+    summary: "Shotgun (slug or buckshot) legal everywhere.",
+    sourceUrl: "https://tpwd.texas.gov/regulations/outdoor-annual/hunting/general-rules",
+    year: YEAR,
+  },
+  {
+    stateCode: "TX", speciesSlug: "whitetail_deer", weaponType: "archery",
+    allowed: true, seasonContext: "archery_season",
+    restrictions: { min_draw_weight_lbs: 25 },
+    summary: "Archery-only season ~ early Oct–early Nov. ≥25# draw.",
+    sourceUrl: "https://tpwd.texas.gov/regulations/outdoor-annual/hunting/general-rules",
+    year: YEAR,
+  },
+
+  // ===========================================================================
+  // PENNSYLVANIA — interesting: semi-auto only legal for big game since 2017
+  // ===========================================================================
+  {
+    stateCode: "PA", speciesSlug: "whitetail_deer", weaponType: "rifle",
+    allowed: true, seasonContext: "firearms_season",
+    restrictions: {
+      semi_auto_allowed: true,
+      magazine_capacity_max: 5,
+      no_full_auto: true,
+    },
+    summary: "Center-fire rifle (incl. semi-auto since 2017). Mag ≤ 5.",
+    sourceUrl: "https://www.pgc.pa.gov/HuntTrap/Pages/default.aspx",
+    year: YEAR,
+  },
+  {
+    stateCode: "PA", speciesSlug: "whitetail_deer", weaponType: "crossbow",
+    allowed: true, seasonContext: "archery_season",
+    restrictions: { min_draw_weight_lbs: 125 },
+    summary: "Crossbow legal during archery + firearms seasons. ≥125# draw.",
+    sourceUrl: "https://www.pgc.pa.gov/HuntTrap/Pages/default.aspx",
+    year: YEAR,
+  },
+
+  // ===========================================================================
+  // FLORIDA — interesting: dogs legal for deer in some zones
+  // ===========================================================================
+  {
+    stateCode: "FL", speciesSlug: "whitetail_deer", weaponType: "rifle",
+    allowed: true, seasonContext: "general_gun",
+    summary: "Rifle legal. Center-fire any caliber typically allowed.",
+    sourceUrl: "https://myfwc.com/hunting/deer/",
+    year: YEAR,
+  },
+  {
+    stateCode: "FL", speciesSlug: "whitetail_deer", weaponType: "dogs",
+    allowed: true, seasonContext: "general_gun",
+    huntUnitOverrides: {
+      allow_zones: ["zone_a", "zone_b", "zone_c", "zone_d"],
+      notes: "Hunting deer with dogs allowed in most zones during general gun season; check specific WMA rules.",
+    },
+    summary: "Hunting deer with trained dogs is legal in FL during general gun season in most zones.",
+    sourceUrl: "https://myfwc.com/hunting/deer/",
+    year: YEAR,
+  },
+
+  // ===========================================================================
+  // NORTH CAROLINA — sample
+  // ===========================================================================
+  {
+    stateCode: "NC", speciesSlug: "whitetail_deer", weaponType: "rifle",
+    allowed: true, seasonContext: "gun_season",
+    summary: "Rifle legal during gun season (mid-Oct–early Jan, zone-dependent).",
+    sourceUrl: "https://www.ncwildlife.org/Hunting",
+    year: YEAR,
+  },
+  {
+    stateCode: "NC", speciesSlug: "whitetail_deer", weaponType: "crossbow",
+    allowed: true, seasonContext: "archery_season",
+    summary: "Crossbow legal during all archery and gun seasons.",
+    sourceUrl: "https://www.ncwildlife.org/Hunting",
+    year: YEAR,
+  },
+];
+
+async function upsert(seed: WeaponSeed): Promise<void> {
+  const [state] = await db
+    .select()
+    .from(states)
+    .where(eq(states.code, seed.stateCode))
+    .limit(1);
+  if (!state) {
+    console.log(`  ! State not found: ${seed.stateCode}`);
+    return;
+  }
+  const [sp] = await db
+    .select()
+    .from(species)
+    .where(eq(species.slug, seed.speciesSlug))
+    .limit(1);
+  if (!sp) {
+    console.log(`  ! Species not found: ${seed.speciesSlug}`);
+    return;
+  }
+
+  const existing = await db
+    .select()
+    .from(weaponRegulations)
+    .where(
+      and(
+        eq(weaponRegulations.stateId, state.id),
+        eq(weaponRegulations.speciesId, sp.id),
+        eq(weaponRegulations.weaponType, seed.weaponType),
+        eq(weaponRegulations.year, seed.year)
+      )
+    )
+    .limit(1);
+
+  const row = {
+    stateId: state.id,
+    speciesId: sp.id,
+    weaponType: seed.weaponType,
+    allowed: seed.allowed,
+    seasonContext: seed.seasonContext ?? null,
+    restrictions: seed.restrictions ?? {},
+    huntUnitOverrides: seed.huntUnitOverrides ?? {},
+    summary: seed.summary,
+    sourceUrl: seed.sourceUrl,
+    year: seed.year,
+    lastVerified: new Date(),
+  };
+
+  if (existing.length > 0) {
+    await db
+      .update(weaponRegulations)
+      .set(row)
+      .where(eq(weaponRegulations.id, existing[0]!.id));
+  } else {
+    await db.insert(weaponRegulations).values(row);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`Seeding ${SEEDS.length} weapon-regulation rows...`);
+  let ok = 0, fail = 0;
+  for (const s of SEEDS) {
+    try {
+      await upsert(s);
+      ok++;
+    } catch (error) {
+      fail++;
+      console.error(
+        `  ✗ ${s.stateCode}/${s.speciesSlug}/${s.weaponType}: ${error}`
+      );
+    }
+  }
+  console.log("");
+  console.log(`Done. ${ok} seeded, ${fail} failed.`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/lib/db/migrations/0100_data_layer_overhaul.sql
+++ b/src/lib/db/migrations/0100_data_layer_overhaul.sql
@@ -1,0 +1,207 @@
+-- =============================================================================
+-- Migration 0100 — Data Layer Overhaul
+-- =============================================================================
+-- Phase 1-4 schema additions in one migration:
+--   1) draw_odds: point-system normalization columns
+--   2) regulation_snapshots + regulation_changes (delta tracking)
+--   3) hunter_education_requirements (new-hunter mode)
+--   4) license_types (per state/species/residency/year)
+--   5) weapon_regulations (equipment-aware advice)
+--   6) public_land_parcels (BLM/USFS overlay cache)
+--
+-- All changes are additive — no destructive ops, no data loss.
+-- Safe to run on prod (idempotent via IF NOT EXISTS where supported).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. draw_odds — point-system normalization
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE draw_odds
+  ADD COLUMN IF NOT EXISTS point_system_type TEXT,
+  ADD COLUMN IF NOT EXISTS effective_points REAL;
+
+COMMENT ON COLUMN draw_odds.point_system_type IS
+  'Categorizes the underlying point math: pure_preference | bonus | bonus_squared | weighted_preference | random | none';
+COMMENT ON COLUMN draw_odds.effective_points IS
+  'Normalized preference-equivalent points (computed from min_points_drawn under point_system_type math). Lets cross-state forecasting compare bonus/preference systems on one axis.';
+
+-- -----------------------------------------------------------------------------
+-- 2. regulation_snapshots — versioned, hash-keyed copies of agency rule docs
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS regulation_snapshots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  state_id UUID NOT NULL REFERENCES states(id) ON DELETE CASCADE,
+  species_id UUID REFERENCES species(id) ON DELETE SET NULL,
+  year INTEGER NOT NULL,
+  doc_type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  url TEXT,
+  source_url TEXT,
+  content_hash TEXT NOT NULL,
+  content_length INTEGER,
+  raw_text_snippet TEXT,
+  extracted_rules JSONB NOT NULL DEFAULT '{}'::jsonb,
+  source_id UUID REFERENCES data_sources(id) ON DELETE SET NULL,
+  previous_snapshot_id UUID,
+  status TEXT NOT NULL DEFAULT 'active',
+  snapshot_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS regulation_snapshots_hash_idx
+  ON regulation_snapshots(state_id, doc_type, year, content_hash);
+CREATE INDEX IF NOT EXISTS regulation_snapshots_state_year_idx
+  ON regulation_snapshots(state_id, year);
+CREATE INDEX IF NOT EXISTS regulation_snapshots_doc_type_idx
+  ON regulation_snapshots(doc_type);
+CREATE INDEX IF NOT EXISTS regulation_snapshots_status_idx
+  ON regulation_snapshots(status);
+CREATE INDEX IF NOT EXISTS regulation_snapshots_snapshot_at_idx
+  ON regulation_snapshots(snapshot_at);
+
+-- -----------------------------------------------------------------------------
+-- 3. regulation_changes — denormalized diff records between snapshots
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS regulation_changes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  from_snapshot_id UUID NOT NULL REFERENCES regulation_snapshots(id) ON DELETE CASCADE,
+  to_snapshot_id UUID NOT NULL REFERENCES regulation_snapshots(id) ON DELETE CASCADE,
+  state_id UUID NOT NULL REFERENCES states(id) ON DELETE CASCADE,
+  species_id UUID REFERENCES species(id) ON DELETE SET NULL,
+  change_type TEXT NOT NULL,
+  severity TEXT NOT NULL DEFAULT 'medium',
+  field_path TEXT,
+  old_value JSONB,
+  new_value JSONB,
+  summary TEXT NOT NULL,
+  impact TEXT,
+  affects_unit_codes JSONB NOT NULL DEFAULT '[]'::jsonb,
+  detected_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS regulation_changes_state_idx ON regulation_changes(state_id);
+CREATE INDEX IF NOT EXISTS regulation_changes_species_idx ON regulation_changes(species_id);
+CREATE INDEX IF NOT EXISTS regulation_changes_type_idx ON regulation_changes(change_type);
+CREATE INDEX IF NOT EXISTS regulation_changes_severity_idx ON regulation_changes(severity);
+CREATE INDEX IF NOT EXISTS regulation_changes_detected_idx ON regulation_changes(detected_at);
+CREATE INDEX IF NOT EXISTS regulation_changes_from_snapshot_idx ON regulation_changes(from_snapshot_id);
+CREATE INDEX IF NOT EXISTS regulation_changes_to_snapshot_idx ON regulation_changes(to_snapshot_id);
+
+-- -----------------------------------------------------------------------------
+-- 4. hunter_education_requirements — per-state new-hunter requirements
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS hunter_education_requirements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  state_id UUID NOT NULL UNIQUE REFERENCES states(id) ON DELETE CASCADE,
+  required_for TEXT NOT NULL DEFAULT 'all_first_time',
+  born_on_or_after INTEGER,
+  minimum_age INTEGER,
+  apprentice_allowed BOOLEAN NOT NULL DEFAULT false,
+  apprentice_max_years INTEGER,
+  accepted_courses JSONB NOT NULL DEFAULT '[]'::jsonb,
+  online_allowed BOOLEAN NOT NULL DEFAULT true,
+  field_day_required BOOLEAN NOT NULL DEFAULT false,
+  typical_cost REAL,
+  reciprocity JSONB NOT NULL DEFAULT '[]'::jsonb,
+  cert_number_format TEXT,
+  bowhunter_ed_required BOOLEAN NOT NULL DEFAULT false,
+  trapper_ed_required BOOLEAN NOT NULL DEFAULT false,
+  source_url TEXT,
+  notes TEXT,
+  last_verified TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS hunter_education_state_idx ON hunter_education_requirements(state_id);
+
+-- -----------------------------------------------------------------------------
+-- 5. license_types — every license/tag/permit per state
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS license_types (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  state_id UUID NOT NULL REFERENCES states(id) ON DELETE CASCADE,
+  species_id UUID REFERENCES species(id) ON DELETE SET NULL,
+  license_code TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  residency TEXT NOT NULL DEFAULT 'all',
+  cost REAL,
+  min_age INTEGER,
+  max_age INTEGER,
+  valid_from TEXT,
+  valid_to TEXT,
+  prerequisites JSONB NOT NULL DEFAULT '{}'::jsonb,
+  is_otc BOOLEAN NOT NULL DEFAULT false,
+  is_draw_entry BOOLEAN NOT NULL DEFAULT false,
+  quantity_limit INTEGER,
+  source_url TEXT,
+  year INTEGER,
+  last_verified TIMESTAMPTZ,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS license_types_unique_idx
+  ON license_types(state_id, species_id, license_code, residency, year);
+CREATE INDEX IF NOT EXISTS license_types_state_idx ON license_types(state_id);
+CREATE INDEX IF NOT EXISTS license_types_species_idx ON license_types(species_id);
+CREATE INDEX IF NOT EXISTS license_types_residency_idx ON license_types(residency);
+CREATE INDEX IF NOT EXISTS license_types_year_idx ON license_types(year);
+
+-- -----------------------------------------------------------------------------
+-- 6. weapon_regulations — equipment-aware advice
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS weapon_regulations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  state_id UUID NOT NULL REFERENCES states(id) ON DELETE CASCADE,
+  species_id UUID NOT NULL REFERENCES species(id) ON DELETE CASCADE,
+  weapon_type TEXT NOT NULL,
+  allowed BOOLEAN NOT NULL DEFAULT true,
+  season_context TEXT,
+  restrictions JSONB NOT NULL DEFAULT '{}'::jsonb,
+  hunt_unit_overrides JSONB NOT NULL DEFAULT '{}'::jsonb,
+  summary TEXT,
+  source_url TEXT,
+  year INTEGER,
+  last_verified TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS weapon_regulations_unique_idx
+  ON weapon_regulations(state_id, species_id, weapon_type, season_context, year);
+CREATE INDEX IF NOT EXISTS weapon_regulations_state_species_idx
+  ON weapon_regulations(state_id, species_id);
+CREATE INDEX IF NOT EXISTS weapon_regulations_weapon_idx ON weapon_regulations(weapon_type);
+CREATE INDEX IF NOT EXISTS weapon_regulations_year_idx ON weapon_regulations(year);
+
+-- -----------------------------------------------------------------------------
+-- 7. public_land_parcels — denormalized BLM/USFS/state overlay cache
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public_land_parcels (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  state_id UUID NOT NULL REFERENCES states(id) ON DELETE CASCADE,
+  land_agency TEXT NOT NULL,
+  name TEXT,
+  parcel_code TEXT,
+  acreage REAL,
+  overlaps_unit_codes JSONB NOT NULL DEFAULT '[]'::jsonb,
+  hunting_allowed BOOLEAN NOT NULL DEFAULT true,
+  access_notes TEXT,
+  source_dataset TEXT,
+  source_url TEXT,
+  geom_centroid JSONB,
+  bounds_bbox JSONB,
+  last_refreshed TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS public_land_state_idx ON public_land_parcels(state_id);
+CREATE INDEX IF NOT EXISTS public_land_agency_idx ON public_land_parcels(land_agency);
+CREATE INDEX IF NOT EXISTS public_land_parcel_code_idx ON public_land_parcels(parcel_code);

--- a/src/lib/db/schema/hunter-knowledge.ts
+++ b/src/lib/db/schema/hunter-knowledge.ts
@@ -1,0 +1,277 @@
+import { relations } from "drizzle-orm";
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  integer,
+  boolean,
+  real,
+  jsonb,
+  uniqueIndex,
+  index,
+} from "drizzle-orm/pg-core";
+import { states, species } from "./hunting";
+
+// ========================
+// HUNTER EDUCATION REQUIREMENTS — what a new hunter needs to do to be
+// legal in each state. Concierge uses this for the "I'm new, where do I start"
+// flow ("In Georgia you need to complete an approved hunter ed course; here are
+// 3 free online options").
+// ========================
+
+export const hunterEducationRequirements = pgTable(
+  "hunter_education_requirements",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    stateId: uuid("state_id")
+      .notNull()
+      .references(() => states.id, { onDelete: "cascade" })
+      .unique(),
+    // Who needs hunter ed: 'all_first_time' | 'born_after_year' | 'age_only' | 'none'
+    requiredFor: text("required_for").notNull().default("all_first_time"),
+    bornOnOrAfter: integer("born_on_or_after"), // e.g. 1969 in some states
+    minimumAge: integer("minimum_age"), // youngest age allowed to take the course
+    // Whether unaccompanied hunters need the course; some states allow
+    // mentored/apprentice licenses to bypass temporarily.
+    apprenticeAllowed: boolean("apprentice_allowed").notNull().default(false),
+    apprenticeMaxYears: integer("apprentice_max_years"),
+    // Accepted course providers (IHEA-USA, NRA, state-specific online, etc).
+    // [{ provider, format: 'in_person' | 'online' | 'hybrid', cost, url }]
+    acceptedCourses: jsonb("accepted_courses").notNull().default([]),
+    onlineAllowed: boolean("online_allowed").notNull().default(true),
+    fieldDayRequired: boolean("field_day_required").notNull().default(false),
+    typicalCost: real("typical_cost"),
+    // Reciprocity: which other state/country certifications are accepted.
+    reciprocity: jsonb("reciprocity").notNull().default([]), // string[] (state codes)
+    // Cert # format / how it's recorded on the license app.
+    certNumberFormat: text("cert_number_format"),
+    // Optional: bow-hunter and trapper ed are sometimes separate requirements.
+    bowhunterEdRequired: boolean("bowhunter_ed_required")
+      .notNull()
+      .default(false),
+    trapperEdRequired: boolean("trapper_ed_required").notNull().default(false),
+    sourceUrl: text("source_url"),
+    notes: text("notes"),
+    lastVerified: timestamp("last_verified", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("hunter_education_state_idx").on(table.stateId),
+  ]
+);
+
+// ========================
+// LICENSE TYPES — every license/tag/permit a hunter might buy. Powers the
+// "Georgia + shotgun → what license do I need?" answer and the
+// new-hunter cost estimator.
+// ========================
+
+export const licenseTypes = pgTable(
+  "license_types",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    stateId: uuid("state_id")
+      .notNull()
+      .references(() => states.id, { onDelete: "cascade" }),
+    // Optional: many license types are species-specific (deer tag, turkey
+    // permit). For broad licenses (combo, sportsman), leave null.
+    speciesId: uuid("species_id").references(() => species.id, {
+      onDelete: "set null",
+    }),
+    // 'base_license' | 'big_game_tag' | 'small_game' | 'turkey_permit'
+    // | 'waterfowl_stamp' | 'archery_stamp' | 'muzzleloader_stamp'
+    // | 'sportsman_combo' | 'lifetime' | 'youth' | 'senior' | 'disabled_vet'
+    // | 'apprentice' | 'landowner' | 'preference_point' | 'bonus_point'
+    // | 'habitat_stamp' | 'application_fee' | 'second_tag' | 'leftover_tag'
+    licenseCode: text("license_code").notNull(),
+    name: text("name").notNull(),
+    description: text("description"),
+    // 'resident' | 'nonresident' | 'all' (e.g. apprentice in some states)
+    residency: text("residency").notNull().default("all"),
+    cost: real("cost"), // base price in USD
+    // Optional age band (helps surface youth/senior rates).
+    minAge: integer("min_age"),
+    maxAge: integer("max_age"),
+    validFrom: text("valid_from"), // ISO date or "calendar_year"
+    validTo: text("valid_to"), // ISO date or null for lifetime
+    // Prerequisites: { hunter_ed: true, prior_license_codes: [...] }
+    prerequisites: jsonb("prerequisites").notNull().default({}),
+    // Whether this license confers OTC tag rights vs. requires draw entry.
+    isOtc: boolean("is_otc").notNull().default(false),
+    isDrawEntry: boolean("is_draw_entry").notNull().default(false),
+    quantityLimit: integer("quantity_limit"), // e.g. 2 turkey tags per season
+    sourceUrl: text("source_url"),
+    year: integer("year"), // applicable license year
+    lastVerified: timestamp("last_verified", { withTimezone: true }),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("license_types_unique_idx").on(
+      table.stateId,
+      table.speciesId,
+      table.licenseCode,
+      table.residency,
+      table.year
+    ),
+    index("license_types_state_idx").on(table.stateId),
+    index("license_types_species_idx").on(table.speciesId),
+    index("license_types_residency_idx").on(table.residency),
+    index("license_types_year_idx").on(table.year),
+  ]
+);
+
+// ========================
+// WEAPON REGULATIONS — what a hunter can legally use, broken down per
+// state/species/season. Powers the equipment-aware concierge: "you have a
+// 12-gauge shotgun in Georgia — for deer you can hunt with slugs in zones
+// X/Y/Z during these dates; for turkey here are the shotshell rules".
+// ========================
+
+export const weaponRegulations = pgTable(
+  "weapon_regulations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    stateId: uuid("state_id")
+      .notNull()
+      .references(() => states.id, { onDelete: "cascade" }),
+    speciesId: uuid("species_id")
+      .notNull()
+      .references(() => species.id, { onDelete: "cascade" }),
+    // Canonical weapon class: 'rifle' | 'shotgun' | 'shotgun_slug' | 'archery'
+    // | 'crossbow' | 'muzzleloader' | 'handgun' | 'air_rifle' | 'falconry'
+    // | 'trapping' | 'dogs' (where allowed)
+    weaponType: text("weapon_type").notNull(),
+    allowed: boolean("allowed").notNull().default(true),
+    // 'general_season' | 'archery_only' | 'muzzleloader_only' | 'rifle_only'
+    // | 'youth_season' | 'late_season' | 'urban_archery' | 'damage_control'
+    seasonContext: text("season_context"),
+    // Granular rules vary wildly: { min_caliber, min_bullet_grain, min_draw_weight,
+    // broadhead_type, mech_or_fixed, magazine_capacity, electronic_optic,
+    // tracer_allowed, suppressor_allowed, range_limit_yards, ... }
+    restrictions: jsonb("restrictions").notNull().default({}),
+    // Specific hunt unit / zone overrides (e.g. "shotgun-only counties in IL"):
+    // { allow_unit_codes: [...], deny_unit_codes: [...] }
+    huntUnitOverrides: jsonb("hunt_unit_overrides").notNull().default({}),
+    // Human-readable rule text for citation/grounding in concierge answers.
+    summary: text("summary"),
+    sourceUrl: text("source_url"),
+    year: integer("year"),
+    lastVerified: timestamp("last_verified", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("weapon_regulations_unique_idx").on(
+      table.stateId,
+      table.speciesId,
+      table.weaponType,
+      table.seasonContext,
+      table.year
+    ),
+    index("weapon_regulations_state_species_idx").on(
+      table.stateId,
+      table.speciesId
+    ),
+    index("weapon_regulations_weapon_idx").on(table.weaponType),
+    index("weapon_regulations_year_idx").on(table.year),
+  ]
+);
+
+// ========================
+// PUBLIC LAND PARCELS — denormalized BLM/USFS/state public-land overlays
+// pre-computed into hunt-unit-keyed records. Powers "how much public land is
+// in this unit" and "where can I actually walk in".
+// ========================
+
+export const publicLandParcels = pgTable(
+  "public_land_parcels",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    stateId: uuid("state_id")
+      .notNull()
+      .references(() => states.id, { onDelete: "cascade" }),
+    // 'BLM' | 'USFS' | 'NPS' | 'USFWS' | 'state_wma' | 'state_park'
+    // | 'state_forest' | 'state_trust' | 'tribal' | 'open_lands_program'
+    landAgency: text("land_agency").notNull(),
+    name: text("name"),
+    // National Forest / WMA / unit name (e.g. "Pike-San Isabel NF").
+    parcelCode: text("parcel_code"),
+    acreage: real("acreage"),
+    // OPS-friendly: which hunt units (unit_code strings) this parcel overlaps.
+    // The actual spatial join is too heavy to keep live in PG without PostGIS
+    // tuning; we cache the result here per refresh.
+    overlapsUnitCodes: jsonb("overlaps_unit_codes").notNull().default([]),
+    // Hunting-specific flags from the source dataset.
+    huntingAllowed: boolean("hunting_allowed").notNull().default(true),
+    accessNotes: text("access_notes"),
+    sourceDataset: text("source_dataset"), // e.g. "BLM Surface Management Agency 2025"
+    sourceUrl: text("source_url"),
+    geomCentroid: jsonb("geom_centroid"), // { lat, lon } for quick mapping
+    boundsBbox: jsonb("bounds_bbox"), // [minLon, minLat, maxLon, maxLat]
+    lastRefreshed: timestamp("last_refreshed", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("public_land_state_idx").on(table.stateId),
+    index("public_land_agency_idx").on(table.landAgency),
+    index("public_land_parcel_code_idx").on(table.parcelCode),
+  ]
+);
+
+// ========================
+// RELATIONS
+// ========================
+
+export const hunterEducationRequirementsRelations = relations(
+  hunterEducationRequirements,
+  ({ one }) => ({
+    state: one(states, {
+      fields: [hunterEducationRequirements.stateId],
+      references: [states.id],
+    }),
+  })
+);
+
+export const licenseTypesRelations = relations(licenseTypes, ({ one }) => ({
+  state: one(states, {
+    fields: [licenseTypes.stateId],
+    references: [states.id],
+  }),
+  species: one(species, {
+    fields: [licenseTypes.speciesId],
+    references: [species.id],
+  }),
+}));
+
+export const weaponRegulationsRelations = relations(
+  weaponRegulations,
+  ({ one }) => ({
+    state: one(states, {
+      fields: [weaponRegulations.stateId],
+      references: [states.id],
+    }),
+    species: one(species, {
+      fields: [weaponRegulations.speciesId],
+      references: [species.id],
+    }),
+  })
+);
+
+export const publicLandParcelsRelations = relations(
+  publicLandParcels,
+  ({ one }) => ({
+    state: one(states, {
+      fields: [publicLandParcels.stateId],
+      references: [states.id],
+    }),
+  })
+);

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -124,6 +124,26 @@ export {
 // Knowledge domain
 export { knowledgeChunks } from "./knowledge-chunks";
 
+// Regulation snapshots + delta tracking
+export {
+  regulationSnapshots,
+  regulationChanges,
+  regulationSnapshotsRelations,
+  regulationChangesRelations,
+} from "./regulation-snapshots";
+
+// Hunter knowledge domain (new-hunter mode + equipment-aware advice)
+export {
+  hunterEducationRequirements,
+  licenseTypes,
+  weaponRegulations,
+  publicLandParcels,
+  hunterEducationRequirementsRelations,
+  licenseTypesRelations,
+  weaponRegulationsRelations,
+  publicLandParcelsRelations,
+} from "./hunter-knowledge";
+
 // Concierge domain
 export {
   stateFeeSchedules,

--- a/src/lib/db/schema/intelligence.ts
+++ b/src/lib/db/schema/intelligence.ts
@@ -41,6 +41,13 @@ export const drawOdds = pgTable(
     maxPointsDrawn: integer("max_points_drawn"),
     avgPointsDrawn: real("avg_points_drawn"),
     drawRate: real("draw_rate"), // 0.0 to 1.0
+    // ----- Point-system normalization (added 2026-05) -----
+    // Categorizes the underlying point math so cross-state comparison is possible.
+    pointSystemType: text("point_system_type"), // 'pure_preference' | 'bonus' | 'bonus_squared' | 'weighted_preference' | 'random' | 'none'
+    // Normalized "effective preference-equivalent points" computed from
+    // minPointsDrawn under the point_system_type math. Lets the ML forecaster
+    // compare AZ bonus, NV bonus², UT 50/50, CO preference on one axis.
+    effectivePoints: real("effective_points"),
     sourceId: uuid("source_id").references(() => dataSources.id, {
       onDelete: "set null",
     }),

--- a/src/lib/db/schema/regulation-snapshots.ts
+++ b/src/lib/db/schema/regulation-snapshots.ts
@@ -1,0 +1,170 @@
+import { relations } from "drizzle-orm";
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  integer,
+  jsonb,
+  uniqueIndex,
+  index,
+} from "drizzle-orm/pg-core";
+import { states, species } from "./hunting";
+import { dataSources } from "./data-sources";
+
+// ========================
+// REGULATION SNAPSHOTS — versioned, hash-keyed copies of agency rule docs.
+// Lets us answer "what changed between 2026 and 2027 regs for CO elk?" by
+// diffing the structured payload, and lets the concierge cite a specific
+// snapshot rather than a moving target.
+// ========================
+
+export const regulationSnapshots = pgTable(
+  "regulation_snapshots",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    stateId: uuid("state_id")
+      .notNull()
+      .references(() => states.id, { onDelete: "cascade" }),
+    speciesId: uuid("species_id").references(() => species.id, {
+      onDelete: "set null",
+    }),
+    year: integer("year").notNull(),
+    // 'big_game_regs' | 'small_game_regs' | 'turkey_regs' | 'waterfowl_regs'
+    // | 'application_brochure' | 'hunt_planner' | 'admin_rules' | 'season_summary'
+    docType: text("doc_type").notNull(),
+    title: text("title").notNull(),
+    url: text("url"),
+    sourceUrl: text("source_url"), // canonical agency URL (may differ from `url` if mirrored)
+    contentHash: text("content_hash").notNull(), // SHA-256 of canonicalized content
+    contentLength: integer("content_length"),
+    rawTextSnippet: text("raw_text_snippet"), // first ~10KB for grounding citations
+    // Parsed/extracted structured rules: { seasons: [...], quotas: {...},
+    // weapon_restrictions: [...], fees: [...], application_window: {...},
+    // nonresident_caps: {...}, point_system_changes: [...], ... }
+    extractedRules: jsonb("extracted_rules").notNull().default({}),
+    sourceId: uuid("source_id").references(() => dataSources.id, {
+      onDelete: "set null",
+    }),
+    // Link to the snapshot this version replaces — supports change tracking.
+    previousSnapshotId: uuid("previous_snapshot_id"),
+    // 'active' | 'archived' | 'superseded'
+    status: text("status").notNull().default("active"),
+    snapshotAt: timestamp("snapshot_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("regulation_snapshots_hash_idx").on(
+      table.stateId,
+      table.docType,
+      table.year,
+      table.contentHash
+    ),
+    index("regulation_snapshots_state_year_idx").on(table.stateId, table.year),
+    index("regulation_snapshots_doc_type_idx").on(table.docType),
+    index("regulation_snapshots_status_idx").on(table.status),
+    index("regulation_snapshots_snapshot_at_idx").on(table.snapshotAt),
+  ]
+);
+
+// ========================
+// REGULATION CHANGES — denormalized diff records, one row per detected change
+// between two snapshots. Lets the concierge surface "CO cut Unit 12 elk
+// quota by 30%" or "WY moved nonresident deadline from May 31 → May 15".
+// ========================
+
+export const regulationChanges = pgTable(
+  "regulation_changes",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    fromSnapshotId: uuid("from_snapshot_id")
+      .notNull()
+      .references(() => regulationSnapshots.id, { onDelete: "cascade" }),
+    toSnapshotId: uuid("to_snapshot_id")
+      .notNull()
+      .references(() => regulationSnapshots.id, { onDelete: "cascade" }),
+    stateId: uuid("state_id")
+      .notNull()
+      .references(() => states.id, { onDelete: "cascade" }),
+    speciesId: uuid("species_id").references(() => species.id, {
+      onDelete: "set null",
+    }),
+    // 'quota_change' | 'season_dates' | 'fee_change' | 'weapon_rule'
+    // | 'deadline_change' | 'point_system' | 'unit_boundary' | 'eligibility'
+    // | 'new_opportunity' | 'closure' | 'other'
+    changeType: text("change_type").notNull(),
+    // 'critical' | 'high' | 'medium' | 'low' — drives whether we proactively
+    // notify users vs. surface only on next playbook regen.
+    severity: text("severity").notNull().default("medium"),
+    fieldPath: text("field_path"), // JSON path into extracted_rules (e.g. "quotas.unit_12.rifle")
+    oldValue: jsonb("old_value"),
+    newValue: jsonb("new_value"),
+    summary: text("summary").notNull(), // human-readable one-liner
+    impact: text("impact"), // longer impact narrative
+    affectsUnitCodes: jsonb("affects_unit_codes").notNull().default([]), // string[]
+    detectedAt: timestamp("detected_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("regulation_changes_state_idx").on(table.stateId),
+    index("regulation_changes_species_idx").on(table.speciesId),
+    index("regulation_changes_type_idx").on(table.changeType),
+    index("regulation_changes_severity_idx").on(table.severity),
+    index("regulation_changes_detected_idx").on(table.detectedAt),
+    index("regulation_changes_from_snapshot_idx").on(table.fromSnapshotId),
+    index("regulation_changes_to_snapshot_idx").on(table.toSnapshotId),
+  ]
+);
+
+// ========================
+// RELATIONS
+// ========================
+
+export const regulationSnapshotsRelations = relations(
+  regulationSnapshots,
+  ({ one, many }) => ({
+    state: one(states, {
+      fields: [regulationSnapshots.stateId],
+      references: [states.id],
+    }),
+    species: one(species, {
+      fields: [regulationSnapshots.speciesId],
+      references: [species.id],
+    }),
+    source: one(dataSources, {
+      fields: [regulationSnapshots.sourceId],
+      references: [dataSources.id],
+    }),
+    changesFrom: many(regulationChanges, { relationName: "from_snapshot" }),
+    changesTo: many(regulationChanges, { relationName: "to_snapshot" }),
+  })
+);
+
+export const regulationChangesRelations = relations(
+  regulationChanges,
+  ({ one }) => ({
+    fromSnapshot: one(regulationSnapshots, {
+      fields: [regulationChanges.fromSnapshotId],
+      references: [regulationSnapshots.id],
+      relationName: "from_snapshot",
+    }),
+    toSnapshot: one(regulationSnapshots, {
+      fields: [regulationChanges.toSnapshotId],
+      references: [regulationSnapshots.id],
+      relationName: "to_snapshot",
+    }),
+    state: one(states, {
+      fields: [regulationChanges.stateId],
+      references: [states.id],
+    }),
+    species: one(species, {
+      fields: [regulationChanges.speciesId],
+      references: [species.id],
+    }),
+  })
+);

--- a/src/services/intelligence/__tests__/point-system-normalizer.test.ts
+++ b/src/services/intelligence/__tests__/point-system-normalizer.test.ts
@@ -60,9 +60,15 @@ describe("point-system-normalizer", () => {
       expect(effectivePoints({ type: "pure_preference" }, 0)).toBe(0);
     });
 
-    it("clamps bonus points to loyalty cap", () => {
+    it("returns bonus points as-is (does NOT clamp by loyaltyBonusCap)", () => {
+      // PR #11 review fix: loyaltyBonusCap describes the +5 loyalty
+      // bonus a state adds for consistent applicants, not a cap on
+      // accumulated bonus points. Hunters with 8 bonus points must
+      // be rated above hunters with 5; the previous clamp collapsed
+      // them together and wrecked ranking.
       expect(effectivePoints({ type: "bonus", loyaltyBonusCap: 5 }, 3)).toBe(3);
-      expect(effectivePoints({ type: "bonus", loyaltyBonusCap: 5 }, 8)).toBe(5);
+      expect(effectivePoints({ type: "bonus", loyaltyBonusCap: 5 }, 8)).toBe(8);
+      expect(effectivePoints({ type: "bonus", loyaltyBonusCap: 5 }, 15)).toBe(15);
     });
 
     it("squares for bonus_squared", () => {

--- a/src/services/intelligence/__tests__/point-system-normalizer.test.ts
+++ b/src/services/intelligence/__tests__/point-system-normalizer.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  getPointSystemRule,
+  effectivePoints,
+  computeNormalizedPointsFields,
+} from "../point-system-normalizer";
+
+describe("point-system-normalizer", () => {
+  describe("getPointSystemRule", () => {
+    it("maps CO to pure_preference", () => {
+      expect(getPointSystemRule("CO", "elk").type).toBe("pure_preference");
+    });
+
+    it("maps NV to bonus_squared", () => {
+      expect(getPointSystemRule("NV", "elk").type).toBe("bonus_squared");
+    });
+
+    it("maps AZ to bonus with loyalty cap", () => {
+      const rule = getPointSystemRule("AZ", "elk");
+      expect(rule.type).toBe("bonus");
+      expect(rule.loyaltyBonusCap).toBe(5);
+    });
+
+    it("maps UT to weighted_preference (50/50)", () => {
+      const rule = getPointSystemRule("UT", "mule_deer");
+      expect(rule.type).toBe("weighted_preference");
+      expect(rule.randomShare).toBe(0.5);
+    });
+
+    it("maps NM to random", () => {
+      expect(getPointSystemRule("NM", "elk").type).toBe("random");
+    });
+
+    it("maps ID to random", () => {
+      expect(getPointSystemRule("ID", "elk").type).toBe("random");
+    });
+
+    it("returns 'none' for unknown states", () => {
+      expect(getPointSystemRule("ZZ", "elk").type).toBe("none");
+    });
+
+    it("is case-insensitive on state codes", () => {
+      expect(getPointSystemRule("co", "elk").type).toBe("pure_preference");
+      expect(getPointSystemRule("nv", null).type).toBe("bonus_squared");
+    });
+  });
+
+  describe("effectivePoints", () => {
+    it("returns null for null/undefined inputs", () => {
+      expect(effectivePoints({ type: "pure_preference" }, null)).toBeNull();
+      expect(effectivePoints({ type: "pure_preference" }, undefined)).toBeNull();
+    });
+
+    it("returns null for negative inputs", () => {
+      expect(effectivePoints({ type: "pure_preference" }, -1)).toBeNull();
+    });
+
+    it("returns raw points for pure_preference", () => {
+      expect(effectivePoints({ type: "pure_preference" }, 7)).toBe(7);
+      expect(effectivePoints({ type: "pure_preference" }, 0)).toBe(0);
+    });
+
+    it("clamps bonus points to loyalty cap", () => {
+      expect(effectivePoints({ type: "bonus", loyaltyBonusCap: 5 }, 3)).toBe(3);
+      expect(effectivePoints({ type: "bonus", loyaltyBonusCap: 5 }, 8)).toBe(5);
+    });
+
+    it("squares for bonus_squared", () => {
+      expect(effectivePoints({ type: "bonus_squared" }, 0)).toBe(0);
+      expect(effectivePoints({ type: "bonus_squared" }, 6)).toBe(36);
+      expect(effectivePoints({ type: "bonus_squared" }, 10)).toBe(100);
+    });
+
+    it("scales for weighted_preference", () => {
+      expect(
+        effectivePoints({ type: "weighted_preference", randomShare: 0.5 }, 4)
+      ).toBe(2);
+      expect(
+        effectivePoints({ type: "weighted_preference", randomShare: 0.3 }, 10)
+      ).toBe(7);
+    });
+
+    it("returns null for random/none", () => {
+      expect(effectivePoints({ type: "random" }, 5)).toBeNull();
+      expect(effectivePoints({ type: "none" }, 5)).toBeNull();
+    });
+  });
+
+  describe("computeNormalizedPointsFields", () => {
+    it("packages both fields for CO elk", () => {
+      expect(computeNormalizedPointsFields("CO", "elk", 8)).toEqual({
+        pointSystemType: "pure_preference",
+        effectivePoints: 8,
+      });
+    });
+
+    it("packages bonus_squared math for NV mule deer", () => {
+      expect(computeNormalizedPointsFields("NV", "mule_deer", 6)).toEqual({
+        pointSystemType: "bonus_squared",
+        effectivePoints: 36,
+      });
+    });
+
+    it("packages random with null effective points for ID", () => {
+      expect(computeNormalizedPointsFields("ID", "elk", 0)).toEqual({
+        pointSystemType: "random",
+        effectivePoints: null,
+      });
+    });
+
+    it("packages weighted half for UT", () => {
+      expect(computeNormalizedPointsFields("UT", "elk", 4)).toEqual({
+        pointSystemType: "weighted_preference",
+        effectivePoints: 2,
+      });
+    });
+  });
+});

--- a/src/services/intelligence/point-system-normalizer.ts
+++ b/src/services/intelligence/point-system-normalizer.ts
@@ -37,8 +37,17 @@ export type PointSystemType =
 
 export interface PointSystemRule {
   type: PointSystemType;
-  // Optional caps / multipliers used by `effectivePoints`.
-  loyaltyBonusCap?: number; // e.g. AZ +5 max
+  /**
+   * Maximum loyalty bonus a state grants on TOP of accumulated bonus
+   * points (e.g. AZ +5 for 5+ consecutive years of applying). This is
+   * NOT a cap on a hunter's total bonus points — those keep
+   * accumulating indefinitely. Used for documentation and future
+   * loyalty-bonus modeling; intentionally NOT applied as a clamp in
+   * `effectivePoints()` (see PR #11 review feedback — the previous
+   * implementation collapsed all AZ hunters with >5 points down to 5,
+   * which under-rated experienced applicants).
+   */
+  loyaltyBonusCap?: number;
   randomShare?: number; // for weighted_preference: portion of tags drawn randomly (0..1)
 }
 
@@ -128,12 +137,17 @@ export function effectivePoints(
 
     case "bonus": {
       // In a bonus system, an applicant with N bonus points has N+1
-      // entries (1 base + N bonus). The minimum points seen drawing is
-      // closer to "preference equivalent" than raw, but agency reporting
-      // already uses min_bonus_points as the cut. We just clamp to the
-      // loyalty cap when set.
-      const cap = rule.loyaltyBonusCap ?? Infinity;
-      return Math.min(minPointsDrawn, cap);
+      // entries (1 base + N bonus). The min_points_drawn value the
+      // agency publishes is already the bonus-point cut, so it maps
+      // approximately linearly to "preference points needed."
+      //
+      // Review feedback (PR #11): the previous implementation clamped
+      // by `loyaltyBonusCap` (5 for AZ), but that cap describes a
+      // separate +5 loyalty bonus a hunter earns on top of accumulated
+      // bonus points — it is NOT a cap on total bonus points. Clamping
+      // collapsed every AZ hunter with >5 bonus points to 5, which
+      // wrecked relative ranking and forecasting.
+      return minPointsDrawn;
     }
 
     case "bonus_squared": {

--- a/src/services/intelligence/point-system-normalizer.ts
+++ b/src/services/intelligence/point-system-normalizer.ts
@@ -1,0 +1,177 @@
+// =============================================================================
+// Point System Normalizer
+// =============================================================================
+// Each western state runs a different math under "preference" or "bonus"
+// points. The ML forecaster can't compare CO (pure preference) to NV (bonus²)
+// to AZ (bonus) without first projecting every record onto a common axis.
+//
+// This module is the single source of truth for that projection. It maps
+// (state_code, species_slug) → point_system_type, and converts raw
+// min_points_drawn into an "effective preference-equivalent" score.
+//
+// The transformation is pure and stateless; it can be called from:
+//   - the ingestion pipeline (when writing new draw_odds rows)
+//   - the ML loader (when computing forecast inputs)
+//   - the recommendation engine (when ranking cross-state options)
+//
+// References (state-specific math derived from each agency's regulations):
+//   - CO: pure preference (max preference wins; ties broken randomly)
+//   - WY: pure preference for resident/nonresident, separate
+//   - AZ: bonus — each app = 1 + bonus_points (loyalty bonus capped at +5)
+//   - NV: bonus² — each app = bonus_points² + 1
+//   - UT: 50/50 split — half tags go to highest-points, half random
+//   - WA: bonus_squared (matches NV)
+//   - NM: random — no point system
+//   - ID: random — no point system
+//   - OR: pure preference
+//   - MT: pure preference (most species)
+// =============================================================================
+
+export type PointSystemType =
+  | "pure_preference"
+  | "bonus"
+  | "bonus_squared"
+  | "weighted_preference" // e.g. UT 50/50: half tags random, half by points
+  | "random"
+  | "none";
+
+export interface PointSystemRule {
+  type: PointSystemType;
+  // Optional caps / multipliers used by `effectivePoints`.
+  loyaltyBonusCap?: number; // e.g. AZ +5 max
+  randomShare?: number; // for weighted_preference: portion of tags drawn randomly (0..1)
+}
+
+// State+species → point system rule. (state_code, species_slug) keys.
+// When a species isn't in the map, the state-level default applies.
+// Defaults fall back to the entry where species_slug is "*".
+const POINT_SYSTEM_RULES: Record<string, PointSystemRule> = {
+  // Colorado — pure preference for all big game
+  "CO:*": { type: "pure_preference" },
+
+  // Wyoming — pure preference, separate resident/nonresident pools
+  "WY:*": { type: "pure_preference" },
+
+  // Arizona — bonus with loyalty cap
+  "AZ:*": { type: "bonus", loyaltyBonusCap: 5 },
+
+  // Nevada — bonus² (each bonus point squared + 1)
+  "NV:*": { type: "bonus_squared" },
+
+  // Utah — 50/50 split for most species
+  "UT:*": { type: "weighted_preference", randomShare: 0.5 },
+  // UT moose, sheep, goat, bison are 50/50 too (no override needed)
+
+  // Washington — bonus²
+  "WA:*": { type: "bonus_squared" },
+
+  // Oregon — pure preference for big game
+  "OR:*": { type: "pure_preference" },
+
+  // Montana — pure preference for big game (most species)
+  "MT:*": { type: "pure_preference" },
+
+  // New Mexico — pure random draw
+  "NM:*": { type: "random" },
+
+  // Idaho — pure random draw (Hunt Planner only reports outcomes, no points)
+  "ID:*": { type: "random" },
+
+  // Alaska — random for most; pure_preference for some draw permits.
+  "AK:*": { type: "random" },
+};
+
+/**
+ * Resolve which point-system rule applies to a given state/species pair.
+ * Falls back through species-specific → state-default → "none".
+ */
+export function getPointSystemRule(
+  stateCode: string,
+  speciesSlug: string | null | undefined
+): PointSystemRule {
+  const upperState = stateCode.toUpperCase();
+  if (speciesSlug) {
+    const speciesKey = `${upperState}:${speciesSlug}`;
+    if (POINT_SYSTEM_RULES[speciesKey]) {
+      return POINT_SYSTEM_RULES[speciesKey];
+    }
+  }
+  const defaultKey = `${upperState}:*`;
+  if (POINT_SYSTEM_RULES[defaultKey]) {
+    return POINT_SYSTEM_RULES[defaultKey];
+  }
+  return { type: "none" };
+}
+
+/**
+ * Convert raw `min_points_drawn` (as reported by the state) into an
+ * effective preference-equivalent score that the ML model can compare
+ * across systems.
+ *
+ * Returns:
+ *   - For pure preference systems: the raw value (already comparable).
+ *   - For bonus systems: an estimate of "preference points to match the
+ *     same draw odds" — this is approximate but better than raw bonus
+ *     points (which under-represent applicants under bonus² math).
+ *   - For random/none: null (point context is meaningless).
+ */
+export function effectivePoints(
+  rule: PointSystemRule,
+  minPointsDrawn: number | null | undefined
+): number | null {
+  if (minPointsDrawn === null || minPointsDrawn === undefined) return null;
+  if (minPointsDrawn < 0) return null;
+
+  switch (rule.type) {
+    case "pure_preference":
+      return minPointsDrawn;
+
+    case "bonus": {
+      // In a bonus system, an applicant with N bonus points has N+1
+      // entries (1 base + N bonus). The minimum points seen drawing is
+      // closer to "preference equivalent" than raw, but agency reporting
+      // already uses min_bonus_points as the cut. We just clamp to the
+      // loyalty cap when set.
+      const cap = rule.loyaltyBonusCap ?? Infinity;
+      return Math.min(minPointsDrawn, cap);
+    }
+
+    case "bonus_squared": {
+      // Probability of draw is proportional to (bp + 1)² + 1.
+      // To convert this back to "what preference points would have given
+      // the same odds," we use the bonus^2 as the effective scale.
+      // This makes a 6-bonus-point hunter equivalent to ~36 preference
+      // points, which is the right order-of-magnitude for comparison.
+      return minPointsDrawn * minPointsDrawn;
+    }
+
+    case "weighted_preference": {
+      // Half the tags go random, half go to highest preference. If
+      // randomShare=0.5, the "preference-equivalent" is effectively
+      // halved (a 5-point hunter is competing for ~half the pool with
+      // the same advantage as a pure-preference state).
+      const ps = rule.randomShare ?? 0.5;
+      return minPointsDrawn * (1 - ps);
+    }
+
+    case "random":
+    case "none":
+      return null;
+  }
+}
+
+/**
+ * Convenience for ingestion: given a draw_odds row's state/species/points,
+ * return the (point_system_type, effective_points) tuple to persist.
+ */
+export function computeNormalizedPointsFields(
+  stateCode: string,
+  speciesSlug: string | null | undefined,
+  minPointsDrawn: number | null | undefined
+): { pointSystemType: PointSystemType; effectivePoints: number | null } {
+  const rule = getPointSystemRule(stateCode, speciesSlug);
+  return {
+    pointSystemType: rule.type,
+    effectivePoints: effectivePoints(rule, minPointsDrawn),
+  };
+}

--- a/src/services/regulations/__tests__/snapshot-service.test.ts
+++ b/src/services/regulations/__tests__/snapshot-service.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  hashContent,
+  canonicalizeText,
+  diffExtractedRules,
+  classifyDiff,
+  summarizeDiff,
+} from "../snapshot-service";
+
+describe("snapshot-service", () => {
+  describe("hashContent", () => {
+    it("produces stable SHA-256 for identical inputs", () => {
+      expect(hashContent("hello")).toEqual(hashContent("hello"));
+    });
+
+    it("produces different hashes for different inputs", () => {
+      expect(hashContent("a")).not.toEqual(hashContent("b"));
+    });
+
+    it("returns a 64-char hex string", () => {
+      expect(hashContent("anything").length).toBe(64);
+      expect(hashContent("anything")).toMatch(/^[0-9a-f]+$/);
+    });
+  });
+
+  describe("canonicalizeText", () => {
+    it("strips trailing whitespace", () => {
+      expect(canonicalizeText("hello   \n  ")).toBe("hello");
+    });
+
+    it("normalizes CRLF to LF", () => {
+      expect(canonicalizeText("a\r\nb")).toBe("a\nb");
+    });
+
+    it("collapses tabs/spaces", () => {
+      expect(canonicalizeText("a\t\t b")).toBe("a b");
+    });
+
+    it("strips page headers", () => {
+      expect(canonicalizeText("text\nPage 12 of 47\nmore")).toBe("text\nmore");
+    });
+
+    it("strips last-updated stamps", () => {
+      expect(canonicalizeText("hello Last updated 2025-09-12 world")).toBe(
+        "hello  world"
+      );
+    });
+
+    it("strips printed-on stamps", () => {
+      expect(canonicalizeText("foo Printed on 9/12/2025 bar")).toBe("foo  bar");
+    });
+  });
+
+  describe("diffExtractedRules", () => {
+    it("returns empty when objects are equal", () => {
+      expect(diffExtractedRules({ a: 1 }, { a: 1 })).toEqual([]);
+    });
+
+    it("flags top-level value changes", () => {
+      const diffs = diffExtractedRules({ a: 1 }, { a: 2 });
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0]?.fieldPath).toBe("a");
+      expect(diffs[0]?.oldValue).toBe(1);
+      expect(diffs[0]?.newValue).toBe(2);
+    });
+
+    it("recurses into nested objects", () => {
+      const diffs = diffExtractedRules(
+        { quotas: { unit_12: { rifle: 100 } } },
+        { quotas: { unit_12: { rifle: 70 } } }
+      );
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0]?.fieldPath).toBe("quotas.unit_12.rifle");
+    });
+
+    it("handles added and removed keys", () => {
+      const diffs = diffExtractedRules({ a: 1 }, { b: 2 });
+      expect(diffs).toHaveLength(2);
+      const paths = diffs.map((d) => d.fieldPath).sort();
+      expect(paths).toEqual(["a", "b"]);
+    });
+
+    it("treats arrays as opaque values (deep equality via JSON)", () => {
+      const diffs = diffExtractedRules(
+        { units: [1, 2, 3] },
+        { units: [1, 2, 4] }
+      );
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0]?.fieldPath).toBe("units");
+    });
+  });
+
+  describe("classifyDiff", () => {
+    it("flags a 30% quota cut as critical", () => {
+      const { changeType, severity } = classifyDiff(
+        "quotas.unit_12.rifle",
+        100,
+        70
+      );
+      expect(changeType).toBe("quota_change");
+      expect(severity).toBe("critical");
+    });
+
+    it("flags a 10% quota change as high", () => {
+      const { severity } = classifyDiff("quotas.unit_5", 100, 88);
+      expect(severity).toBe("high");
+    });
+
+    it("flags a small quota change as medium", () => {
+      const { severity } = classifyDiff("quotas.unit_5", 100, 97);
+      expect(severity).toBe("medium");
+    });
+
+    it("flags season date changes as high", () => {
+      expect(classifyDiff("seasons.rifle.startDate", "2025-10-12", "2025-10-19").severity).toBe(
+        "high"
+      );
+    });
+
+    it("flags deadline changes as critical", () => {
+      expect(classifyDiff("application_deadline", "2026-05-31", "2026-05-15").severity).toBe(
+        "critical"
+      );
+    });
+
+    it("flags fee changes as medium", () => {
+      expect(classifyDiff("fees.nr_elk", 685, 720).severity).toBe("medium");
+    });
+
+    it("falls back to 'other' for unknown paths", () => {
+      const r = classifyDiff("misc.unknown_field", 1, 2);
+      expect(r.changeType).toBe("other");
+      expect(r.severity).toBe("low");
+    });
+  });
+
+  describe("summarizeDiff", () => {
+    it("formats added values", () => {
+      expect(summarizeDiff("a", undefined, 5)).toBe("a: (none) → 5");
+    });
+
+    it("formats removed values", () => {
+      expect(summarizeDiff("a", 5, undefined)).toBe("a: 5 → (removed)");
+    });
+
+    it("formats changed values", () => {
+      expect(summarizeDiff("quotas.u12", 100, 70)).toBe("quotas.u12: 100 → 70");
+    });
+  });
+});

--- a/src/services/regulations/snapshot-service.ts
+++ b/src/services/regulations/snapshot-service.ts
@@ -62,8 +62,9 @@ export function canonicalizeText(text: string): string {
       .replace(/\r\n/g, "\n")
       .replace(/[ \t]+/g, " ")
       .replace(/\n{3,}/g, "\n\n")
-      // Drop common per-page headers/footers (e.g. "Page 12 of 47")
-      .replace(/^\s*Page\s+\d+\s+of\s+\d+\s*$/gim, "")
+      // Drop common per-page headers/footers (e.g. "Page 12 of 47"), incl.
+      // the trailing newline so we don't leave a blank line behind.
+      .replace(/^\s*Page\s+\d+\s+of\s+\d+\s*\n?/gim, "")
       // Drop "Last updated YYYY-MM-DD" stamps
       .replace(/Last\s+updated:?\s+\d{4}-\d{2}-\d{2}/gi, "")
       // Drop printed-on timestamps

--- a/src/services/regulations/snapshot-service.ts
+++ b/src/services/regulations/snapshot-service.ts
@@ -1,0 +1,320 @@
+// =============================================================================
+// Regulation Snapshot Service
+// =============================================================================
+// Takes a freshly-fetched regulation document and produces a versioned
+// snapshot. If a snapshot already exists for the same (state, doc_type, year)
+// and the content hash matches, this is a no-op (idempotent re-ingest).
+// Otherwise, a new snapshot is created, the previous one is marked
+// "superseded", and a denormalized diff is written to `regulation_changes`
+// so the concierge can surface "what changed since last year".
+// =============================================================================
+
+import { createHash } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  regulationSnapshots,
+  regulationChanges,
+} from "@/lib/db/schema";
+
+const LOG_PREFIX = "[regulations:snapshot]";
+
+export interface SnapshotInput {
+  stateId: string;
+  speciesId?: string | null;
+  year: number;
+  docType: string;
+  title: string;
+  url?: string | null;
+  sourceUrl?: string | null;
+  // The full canonical text of the document (already stripped of
+  // boilerplate so the hash is stable across cosmetic agency edits).
+  canonicalText: string;
+  // Structured rules extracted from the document.
+  extractedRules?: Record<string, unknown>;
+  sourceId?: string | null;
+}
+
+export interface SnapshotResult {
+  snapshotId: string;
+  isNew: boolean; // true if the hash didn't already exist for this slot
+  changesDetected: number;
+}
+
+/**
+ * SHA-256 of the canonical text. Used as the content-addressable key for
+ * snapshots — two ingestions of the same doc produce the same hash even if
+ * the file was re-downloaded.
+ */
+export function hashContent(canonicalText: string): string {
+  return createHash("sha256").update(canonicalText, "utf8").digest("hex");
+}
+
+/**
+ * Canonicalize free text so cosmetic agency edits (whitespace, page
+ * headers, last-modified stamps) don't produce false-positive deltas.
+ * Conservative — only strips boilerplate that's known-meaningless.
+ */
+export function canonicalizeText(text: string): string {
+  return (
+    text
+      // Normalize whitespace
+      .replace(/\r\n/g, "\n")
+      .replace(/[ \t]+/g, " ")
+      .replace(/\n{3,}/g, "\n\n")
+      // Drop common per-page headers/footers (e.g. "Page 12 of 47")
+      .replace(/^\s*Page\s+\d+\s+of\s+\d+\s*$/gim, "")
+      // Drop "Last updated YYYY-MM-DD" stamps
+      .replace(/Last\s+updated:?\s+\d{4}-\d{2}-\d{2}/gi, "")
+      // Drop printed-on timestamps
+      .replace(/Printed\s+on:?\s+\d{1,2}\/\d{1,2}\/\d{2,4}/gi, "")
+      .trim()
+  );
+}
+
+/**
+ * Walk two extracted-rules objects and produce a list of diff records.
+ * This is intentionally simple — recursive walk by key path. The output
+ * is good enough for the concierge to say "quota for unit X dropped 30%".
+ */
+export function diffExtractedRules(
+  fromRules: Record<string, unknown>,
+  toRules: Record<string, unknown>,
+  pathPrefix = ""
+): Array<{
+  fieldPath: string;
+  oldValue: unknown;
+  newValue: unknown;
+}> {
+  const diffs: Array<{
+    fieldPath: string;
+    oldValue: unknown;
+    newValue: unknown;
+  }> = [];
+
+  const allKeys = new Set([
+    ...Object.keys(fromRules ?? {}),
+    ...Object.keys(toRules ?? {}),
+  ]);
+
+  for (const key of allKeys) {
+    const path = pathPrefix ? `${pathPrefix}.${key}` : key;
+    const oldVal = fromRules?.[key];
+    const newVal = toRules?.[key];
+
+    const bothObjects =
+      oldVal !== null &&
+      newVal !== null &&
+      typeof oldVal === "object" &&
+      typeof newVal === "object" &&
+      !Array.isArray(oldVal) &&
+      !Array.isArray(newVal);
+
+    if (bothObjects) {
+      diffs.push(
+        ...diffExtractedRules(
+          oldVal as Record<string, unknown>,
+          newVal as Record<string, unknown>,
+          path
+        )
+      );
+      continue;
+    }
+
+    // Stable JSON comparison
+    if (JSON.stringify(oldVal) !== JSON.stringify(newVal)) {
+      diffs.push({ fieldPath: path, oldValue: oldVal, newValue: newVal });
+    }
+  }
+
+  return diffs;
+}
+
+/**
+ * Heuristic classifier — map a diff field path to a (change_type, severity).
+ * Lets the concierge prioritize "quota cut 30%" over "URL formatting fix".
+ */
+export function classifyDiff(
+  fieldPath: string,
+  oldValue: unknown,
+  newValue: unknown
+): { changeType: string; severity: "critical" | "high" | "medium" | "low" } {
+  const lowered = fieldPath.toLowerCase();
+
+  if (lowered.includes("quota") || lowered.includes("tags")) {
+    // Magnitude-aware: big quota cuts are critical, small are medium.
+    if (
+      typeof oldValue === "number" &&
+      typeof newValue === "number" &&
+      oldValue > 0
+    ) {
+      const pctChange = Math.abs(newValue - oldValue) / oldValue;
+      if (pctChange >= 0.25) return { changeType: "quota_change", severity: "critical" };
+      if (pctChange >= 0.1) return { changeType: "quota_change", severity: "high" };
+      return { changeType: "quota_change", severity: "medium" };
+    }
+    return { changeType: "quota_change", severity: "medium" };
+  }
+  if (lowered.includes("season") || lowered.includes("date")) {
+    return { changeType: "season_dates", severity: "high" };
+  }
+  if (lowered.includes("fee") || lowered.includes("cost") || lowered.includes("price")) {
+    return { changeType: "fee_change", severity: "medium" };
+  }
+  if (lowered.includes("weapon") || lowered.includes("caliber") || lowered.includes("broadhead")) {
+    return { changeType: "weapon_rule", severity: "high" };
+  }
+  if (lowered.includes("deadline")) {
+    return { changeType: "deadline_change", severity: "critical" };
+  }
+  if (lowered.includes("point") || lowered.includes("preference") || lowered.includes("bonus")) {
+    return { changeType: "point_system", severity: "high" };
+  }
+  if (lowered.includes("eligibility") || lowered.includes("resident")) {
+    return { changeType: "eligibility", severity: "high" };
+  }
+  if (lowered.includes("closure") || lowered.includes("closed")) {
+    return { changeType: "closure", severity: "critical" };
+  }
+  return { changeType: "other", severity: "low" };
+}
+
+/**
+ * Produce a short, human-readable summary line for a diff record. Used
+ * directly as the `summary` column and surfaced verbatim to the concierge.
+ */
+export function summarizeDiff(
+  fieldPath: string,
+  oldValue: unknown,
+  newValue: unknown
+): string {
+  const oldDisplay =
+    oldValue === undefined || oldValue === null
+      ? "(none)"
+      : JSON.stringify(oldValue);
+  const newDisplay =
+    newValue === undefined || newValue === null
+      ? "(removed)"
+      : JSON.stringify(newValue);
+  return `${fieldPath}: ${oldDisplay} → ${newDisplay}`;
+}
+
+/**
+ * Ingest one regulation document, snapshotting it and producing diff
+ * records against the previous active snapshot for the same slot.
+ *
+ * Idempotent: re-running with identical content is a no-op.
+ */
+export async function ingestSnapshot(input: SnapshotInput): Promise<SnapshotResult> {
+  const canonical = canonicalizeText(input.canonicalText);
+  const hash = hashContent(canonical);
+
+  // Find prior active snapshot for the same (state, doc_type, year).
+  const [prior] = await db
+    .select()
+    .from(regulationSnapshots)
+    .where(
+      and(
+        eq(regulationSnapshots.stateId, input.stateId),
+        eq(regulationSnapshots.docType, input.docType),
+        eq(regulationSnapshots.year, input.year),
+        eq(regulationSnapshots.status, "active")
+      )
+    )
+    .orderBy(desc(regulationSnapshots.snapshotAt))
+    .limit(1);
+
+  // Same content as last time — nothing to do.
+  if (prior && prior.contentHash === hash) {
+    console.log(
+      `${LOG_PREFIX} hash unchanged for ${input.docType}/${input.year} state=${input.stateId} — skipping`
+    );
+    return { snapshotId: prior.id, isNew: false, changesDetected: 0 };
+  }
+
+  // Insert new snapshot (or first-ever snapshot for this slot).
+  const [inserted] = await db
+    .insert(regulationSnapshots)
+    .values({
+      stateId: input.stateId,
+      speciesId: input.speciesId ?? null,
+      year: input.year,
+      docType: input.docType,
+      title: input.title,
+      url: input.url ?? null,
+      sourceUrl: input.sourceUrl ?? null,
+      contentHash: hash,
+      contentLength: canonical.length,
+      rawTextSnippet: canonical.slice(0, 10_000),
+      extractedRules: input.extractedRules ?? {},
+      sourceId: input.sourceId ?? null,
+      previousSnapshotId: prior?.id ?? null,
+      status: "active",
+    })
+    .returning();
+
+  if (!inserted) {
+    throw new Error("Failed to insert regulation snapshot");
+  }
+  const newSnapshot = inserted;
+
+  // If there was a prior, mark it superseded and write diff records.
+  let changesDetected = 0;
+  if (prior) {
+    await db
+      .update(regulationSnapshots)
+      .set({ status: "superseded" })
+      .where(eq(regulationSnapshots.id, prior.id));
+
+    const oldRules = (prior.extractedRules ?? {}) as Record<string, unknown>;
+    const newRules = (input.extractedRules ?? {}) as Record<string, unknown>;
+    const diffs = diffExtractedRules(oldRules, newRules);
+
+    if (diffs.length > 0) {
+      const rows = diffs.map((d) => {
+        const { changeType, severity } = classifyDiff(
+          d.fieldPath,
+          d.oldValue,
+          d.newValue
+        );
+        return {
+          fromSnapshotId: prior.id,
+          toSnapshotId: newSnapshot.id,
+          stateId: input.stateId,
+          speciesId: input.speciesId ?? null,
+          changeType,
+          severity,
+          fieldPath: d.fieldPath,
+          oldValue: d.oldValue ?? null,
+          newValue: d.newValue ?? null,
+          summary: summarizeDiff(d.fieldPath, d.oldValue, d.newValue),
+          impact: null,
+          affectsUnitCodes: extractAffectedUnits(d.fieldPath),
+        };
+      });
+
+      await db.insert(regulationChanges).values(rows);
+      changesDetected = rows.length;
+    }
+  }
+
+  console.log(
+    `${LOG_PREFIX} snapshotted ${input.docType}/${input.year} state=${input.stateId} hash=${hash.slice(0, 12)} changes=${changesDetected}`
+  );
+
+  return {
+    snapshotId: newSnapshot.id,
+    isNew: true,
+    changesDetected,
+  };
+}
+
+/**
+ * Extract any `unit_NNN` style hunt unit codes from a diff field path so the
+ * regulation_changes record can be filtered by affected unit downstream.
+ */
+function extractAffectedUnits(fieldPath: string): string[] {
+  const matches = fieldPath.match(/unit[_-]?([A-Z0-9]+)/gi);
+  if (!matches) return [];
+  return matches.map((m) => m.replace(/unit[_-]?/i, "").toUpperCase());
+}

--- a/src/services/regulations/snapshot-service.ts
+++ b/src/services/regulations/snapshot-service.ts
@@ -10,7 +10,7 @@
 // =============================================================================
 
 import { createHash } from "node:crypto";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   regulationSnapshots,
@@ -210,18 +210,28 @@ export async function ingestSnapshot(input: SnapshotInput): Promise<SnapshotResu
   const canonical = canonicalizeText(input.canonicalText);
   const hash = hashContent(canonical);
 
-  // Find prior active snapshot for the same (state, doc_type, year).
+  // Find prior active snapshot for the same slot. Review feedback
+  // (StrongestAvengerStack on PR #11): omitting speciesId from the
+  // dedupe key allowed two species in the same state/year/docType to
+  // match each other's prior snapshot, corrupting the diff history
+  // (e.g. a CO elk regs ingest could diff against the previous CO
+  // mule deer regs row). Slot key is now
+  // (state, species, docType, year, status). speciesId is nullable in
+  // the schema — for state-wide docs we explicitly match IS NULL so
+  // those still dedupe properly amongst themselves.
+  const slotConditions = [
+    eq(regulationSnapshots.stateId, input.stateId),
+    eq(regulationSnapshots.docType, input.docType),
+    eq(regulationSnapshots.year, input.year),
+    eq(regulationSnapshots.status, "active"),
+    input.speciesId
+      ? eq(regulationSnapshots.speciesId, input.speciesId)
+      : isNull(regulationSnapshots.speciesId),
+  ];
   const [prior] = await db
     .select()
     .from(regulationSnapshots)
-    .where(
-      and(
-        eq(regulationSnapshots.stateId, input.stateId),
-        eq(regulationSnapshots.docType, input.docType),
-        eq(regulationSnapshots.year, input.year),
-        eq(regulationSnapshots.status, "active")
-      )
-    )
+    .where(and(...slotConditions))
     .orderBy(desc(regulationSnapshots.snapshotAt))
     .limit(1);
 


### PR DESCRIPTION
## Status: Ready for morning review (still a draft until you flip it)

This is the data-layer overhaul Mitch requested overnight. Two commits on the branch, 70/70 tests passing, typecheck clean. **Do not merge until you've read the apply order below.**

## What landed

### Schema (additive — no destructive changes)

- `draw_odds.point_system_type` + `draw_odds.effective_points` — cross-state point comparison (CO preference vs NV bonus² vs AZ bonus collapse onto a common axis).
- `regulation_snapshots` + `regulation_changes` — hash-keyed rule-doc versioning + denormalized diffs. Powers proactive 'your strategy needs updating' alerts.
- `hunter_education_requirements` — per-state new-hunter rules.
- `license_types` — every license/tag/permit per state/species/residency/year.
- `weapon_regulations` — equipment-aware advice with hunt-unit overrides.
- `public_land_parcels` — BLM/USFS/NPS/USFWS overlay cache.

Migration: `src/lib/db/migrations/0100_data_layer_overhaul.sql` (idempotent — safe to apply on prod).

### New services

- `src/services/intelligence/point-system-normalizer.ts` — pure-function projection of raw `min_points` onto a state-agnostic preference-equivalent. 19 unit tests.
- `src/services/regulations/snapshot-service.ts` — content-hash + canonical-text dedupe + structured-rules diff + severity classifier + summarizer. 24 unit tests.

### Seeds shipped

- `seed-data-sources-western.ts` — 12 western states activated (CO/WY/AZ/NV/UT/ID/OR/MT/NM/WA/AK/CA). Existing scheduler picks them up automatically.
- `seed-data-sources-eastern.ts` — 20 eastern/southern/midwest states (GA/PA/TX/FL/NC/NY/OH/MI/VA/TN/AL/MS/LA/AR/SC/WI/MN/IL/IN/MO).
- `seed-hunter-education.ts` — 24 priority states with verified hunter-ed rules + online course providers.
- `seed-license-types-core.ts` — 70+ license rows (resident + nonresident pricing, OTC vs draw flags) for priority states.
- `seed-weapon-regulations.ts` — weapon rules with GA shotgun-county overrides and Texas DFW shotgun-only counties; includes negative rules (e.g. 'rifles NOT legal for GA turkey').

### ML loader

- `ml/data/loader.py` — `load_point_history` + `load_training_data` now expose `effective_points` + `point_system_type` with backward-compat fallback to raw `min_points` for un-backfilled rows.

### Enrichment

- `scripts/enrich-public-land.ts` — ArcGIS REST client that pulls BLM Surface Management + USFS National Forests + NPS Parks + USFWS Refuges into `public_land_parcels`. Captures parcel inventory + centroid + bbox today; spatial-join into `hunt_units.public_land_pct` is the follow-up (needs PostGIS).

## What's intentionally NOT done

- Spatial join (PostGIS) for public-land % per hunt_unit — script captures parcels today, the actual ST_Intersects pass is a follow-up.
- Live scraper execution against real agency endpoints — schema + configs are ready; first scheduled run will validate the parsers.
- Backfill of `point_system_type` / `effective_points` for existing draw_odds rows — needs a one-shot SQL UPDATE using the normalizer to compute per-row. (I left this out because it touches prod data; you should decide whether to backfill in bulk or trickle-fill on next ingest.)
- New-hunter UX — explicitly scoped out by Mitch ("focus on the data layer now and UX later").

## Apply order for production

```bash
# 1. Apply the migration (additive, idempotent, safe to re-run)
psql $DATABASE_URL -f src/lib/db/migrations/0100_data_layer_overhaul.sql

# 2. Run the seeds in this order:
pnpm tsx scripts/seed-data-sources-western.ts
pnpm tsx scripts/seed-data-sources-eastern.ts
pnpm tsx scripts/seed-hunter-education.ts
pnpm tsx scripts/seed-license-types-core.ts
pnpm tsx scripts/seed-weapon-regulations.ts

# 3. (Optional) Run public-land enrichment per state:
pnpm tsx scripts/enrich-public-land.ts --state=CO

# 4. Restart the ingestion worker — the scheduler auto-discovers new data_sources rows.
```

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings, unrelated)
- [x] `npm test` — 70/70 passing (added 43 new tests for normalizer + snapshot service)
- [ ] Migration applies cleanly on a fresh dev DB (Mitch to verify in the morning)
- [ ] Seeds run without unique-key conflicts (Mitch to verify in the morning)
- [ ] Scheduler picks up new data_sources rows and creates repeatable BullMQ jobs (verify after first scheduler restart)

## Total impact

- 17 files changed, 4500+ insertions across 2 commits
- 6 new schema tables + 2 new columns
- 5 new seed scripts covering 32 states
- 2 new pure-function services (43 unit tests)
- 1 new ArcGIS enrichment client
- ML loader prepared for normalized point system math

🤖 Built overnight by Claude Code