### PR TITLE
fix(ui): dashboard + profile polish — dedupe state codes, Enter-to-send, drop duplicate Edit Profile, reconcile assistant name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,12 @@
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_NAME="HuntLogic Concierge"
 NEXT_PUBLIC_BRAND_NAME="HuntLogic"
-NEXT_PUBLIC_AI_ASSISTANT_NAME="Teddy"
+# The in-app concierge displays "Grizz" everywhere (ConciergeChatCard,
+# ChatWidget, ChatInput defaults). The Telegram bot is still branded as
+# "TeddyLogicBot" — keep these distinct until the Telegram channel is
+# migrated. If you want to test a different concierge name in the app,
+# override NEXT_PUBLIC_AI_ASSISTANT_NAME here.
+NEXT_PUBLIC_AI_ASSISTANT_NAME="Grizz"
 SUPPORT_EMAIL=support@huntlogic.com
 TELEGRAM_BOT_HANDLE=@TeddyLogicBot
 NEXT_PUBLIC_TELEGRAM_BOT_URL=https://t.me/TeddyLogicBot

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -61,13 +61,20 @@ export default function DashboardPage() {
           const diff = new Date(d.date).getTime() - now;
           return diff > 0 && diff < sevenDays;
         })
-        .map((d) => ({
-          id: `alert-${d.id}`,
-          type: "urgent" as const,
-          message: `${d.stateCode} ${d.title} — deadline in ${Math.ceil((new Date(d.date).getTime() - now) / (24 * 60 * 60 * 1000))} days`,
-          ctaLabel: "View",
-          ctaHref: "/calendar",
-        }));
+        .map((d) => {
+          // Deadline titles already begin with the state code (e.g. "WY Elk
+          // Nonresident Draw Results"), so only prepend the state code when
+          // it's missing — avoids "WY WY ..." double-prefix.
+          const titleHasState = d.stateCode && d.title.startsWith(`${d.stateCode} `);
+          const displayTitle = titleHasState ? d.title : `${d.stateCode} ${d.title}`.trim();
+          return {
+            id: `alert-${d.id}`,
+            type: "urgent" as const,
+            message: `${displayTitle} — deadline in ${Math.ceil((new Date(d.date).getTime() - now) / (24 * 60 * 60 * 1000))} days`,
+            ctaLabel: "View",
+            ctaHref: "/calendar",
+          };
+        });
 
       // Map actions to component shape
       const priorityMap: Record<string, "urgent" | "high" | "medium" | "low"> = {

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -10,7 +10,6 @@ import {
   ChevronRight,
   Settings,
   Edit3,
-  Compass,
   AlertCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -26,14 +25,10 @@ interface ProfileData {
   onboardingComplete: boolean;
 }
 
+// "Edit Hunt Profile" is intentionally NOT in this list — it has its own
+// prominent CTA card above the stats. Including it here too produced a
+// duplicate row directly underneath.
 const settingsLinks = [
-  {
-    href: "/profile/preferences",
-    label: "Edit Hunt Profile",
-    icon: Compass,
-    description:
-      "Update species, states, budget, travel, timeline, weapons, and hunt style",
-  },
   {
     href: "/profile/points",
     label: "Manage Points",

--- a/src/app/api/v1/dashboard/changes/route.ts
+++ b/src/app/api/v1/dashboard/changes/route.ts
@@ -48,10 +48,18 @@ export async function GET() {
       const daysUntil = Math.ceil(
         (new Date(d.deadlineDate).getTime() - Date.now()) / (24 * 60 * 60 * 1000)
       );
+      // Deadline titles already begin with the state code (e.g. "WY Elk
+      // Nonresident Draw Results"), so only prepend the state code when
+      // it's missing — avoids "WY WY ..." double-prefix on the dashboard.
+      const titleHasState =
+        d.stateCode && d.title.startsWith(`${d.stateCode} `);
+      const displayTitle = titleHasState
+        ? d.title
+        : `${d.stateCode} ${d.title}`.trim();
       changes.push({
         id: `deadline-${d.id}`,
         type: daysUntil <= 7 ? "deadline_soon" : "deadline_new",
-        title: `${d.stateCode} ${d.title}`,
+        title: displayTitle,
         description: `${d.deadlineType} deadline in ${daysUntil} day${daysUntil !== 1 ? "s" : ""}`,
         actionUrl: "/calendar",
         icon: "deadline",

--- a/src/components/dashboard/ConciergeChatCard.tsx
+++ b/src/components/dashboard/ConciergeChatCard.tsx
@@ -177,7 +177,15 @@ export function ConciergeChatCard({
         ))}
       </div>
 
-      {/* Input */}
+      {/* Input
+         *
+         * Form-level onSubmit covers native Enter-to-submit, but during prod
+         * UX testing the form submission silently dropped some keystrokes
+         * (likely a focus/timing issue with the suggested-prompt buttons that
+         * unmount when messages.length === 0). Adding an explicit onKeyDown
+         * fallback on the input guarantees Enter always sends a non-empty
+         * trimmed message regardless of focus state.
+         */}
       <form
         className="mt-3 flex items-center gap-2"
         onSubmit={(e) => {
@@ -189,6 +197,12 @@ export function ConciergeChatCard({
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send(input);
+            }
+          }}
           placeholder="Ask about points, units, deadlines…"
           className="min-h-[40px] flex-1 rounded-lg border border-brand-sage/20 bg-white px-3 py-2 text-sm text-brand-bark placeholder:text-brand-sage/60 focus:border-brand-forest focus:outline-none focus:ring-1 focus:ring-brand-forest/30 dark:border-brand-sage/30 dark:bg-brand-bark/40 dark:text-brand-cream"
           disabled={isLoading}


### PR DESCRIPTION
## Summary

Smallest-blast-radius cleanup PR from the prod UX walkthrough.

- **Dashboard deadline alerts:** `${stateCode} ${title}` was double-prefixing because deadline titles already begin with the state code (e.g. "WY Elk Nonresident Draw Results"). Result was "WY WY Elk ..." everywhere. Now only prepends when the title doesn't already start with the state code.
- **"Since you were last here" widget:** same bug in `api/v1/dashboard/changes`. Same fix.
- **Profile page:** "Edit Hunt Profile" appeared twice — once as the prominent top CTA card, again as the first row of the settings-links list. Dropped the duplicate.
- **Dashboard concierge chat:** Enter-to-send was unreliable (form-level onSubmit was OK in isolation but raced with the suggested-prompt buttons unmounting on first message). Added explicit `onKeyDown` fallback on the input.
- **`.env.example`:** `NEXT_PUBLIC_AI_ASSISTANT_NAME` was "Teddy" but the in-app UI is branded "Grizz" everywhere. Updated the env default to match. Telegram handle (`@TeddyLogicBot`) stays as-is.

## Test plan

- [ ] Visit `/dashboard` — deadline alerts show single state code ("WY Elk ..." not "WY WY Elk ...")
- [ ] "Since you were last here" widget shows single state code
- [ ] Visit `/profile` — "Edit Hunt Profile" only appears once (the top CTA card)
- [ ] Dashboard concierge chat: typing a question and pressing Enter sends it

🤖 Generated with [Claude Code](https://claude.com/claude-code)