### PR TITLE
fix(api): real species count on /explore + accurate profile counters

### DIFF
--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -72,18 +72,43 @@ export default function ProfilePage() {
             raw.completeness !== null && typeof raw.completeness === "object"
               ? (raw.completeness?.score ?? 0)
               : (raw.completeness ?? 0),
-          statesActive: raw.statesActive ?? 0,
+          // Server-side derived counters (added in PR fixing #18/#19). The
+          // fallbacks below are defensive — they kick in only if the API
+          // doesn't return the new fields (e.g. during deploy windows).
+          statesActive:
+            raw.statesActive ??
+            (Array.isArray(raw.preferences)
+              ? new Set([
+                  ...raw.preferences
+                    .filter(
+                      (p: { category: string; value: unknown }) =>
+                        p.category === "state_interest" && p.value !== false,
+                    )
+                    .map((p: { key: string }) => p.key),
+                  ...(Array.isArray(raw.pointHoldings)
+                    ? raw.pointHoldings.map(
+                        (h: { stateCode: string }) => h.stateCode,
+                      )
+                    : []),
+                ]).size
+              : 0),
           speciesTracked:
             raw.speciesTracked ??
             (Array.isArray(raw.preferences)
               ? raw.preferences.filter(
-                  (p: { category: string }) =>
-                    p.category === "species_interest",
+                  (p: { category: string; value: unknown }) =>
+                    p.category === "species_interest" && p.value !== false,
                 ).length
               : 0),
           totalPoints:
             raw.totalPoints ??
-            (Array.isArray(raw.pointHoldings) ? raw.pointHoldings.length : 0),
+            (Array.isArray(raw.pointHoldings)
+              ? raw.pointHoldings.reduce(
+                  (sum: number, h: { points?: number }) =>
+                    sum + (h.points ?? 0),
+                  0,
+                )
+              : 0),
           onboardingComplete: raw.onboardingComplete ?? false,
         });
         setLoadError(null);

--- a/src/app/api/v1/explore/states/[stateCode]/route.ts
+++ b/src/app/api/v1/explore/states/[stateCode]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { states, species, stateSpecies } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 export async function GET(
   _request: NextRequest,
@@ -18,10 +18,12 @@ export async function GET(
       return NextResponse.json({ error: "State not found" }, { status: 404 });
     }
 
-    const speciesData = await db
+    // First: pull the canonical curated state_species metadata.
+    const curated = await db
       .select({
         stateCode: states.code,
         stateName: states.name,
+        speciesId: species.id,
         speciesSlug: species.slug,
         speciesName: species.commonName,
         hasDraw: stateSpecies.hasDraw,
@@ -35,6 +37,83 @@ export async function GET(
       .innerJoin(species, eq(stateSpecies.speciesId, species.id))
       .where(eq(stateSpecies.stateId, state.id));
 
+    const curatedSpeciesIds = new Set(curated.map((r) => r.speciesId));
+
+    // Then: derive any species we have observational data for that aren't
+    // in the curated metadata yet. This lets the UI surface "yes, we know
+    // about CO elk" even when the state_species seed is incomplete.
+    const derived = await db
+      .select({
+        speciesId: species.id,
+        speciesSlug: species.slug,
+        speciesName: species.commonName,
+        hasDrawData: sql<boolean>`EXISTS (
+          SELECT 1 FROM draw_odds
+          WHERE draw_odds.state_id = ${state.id}
+            AND draw_odds.species_id = species.id
+        )`,
+        hasSeasons: sql<boolean>`EXISTS (
+          SELECT 1 FROM seasons
+          WHERE seasons.state_id = ${state.id}
+            AND seasons.species_id = species.id
+        )`,
+        hasUnits: sql<boolean>`EXISTS (
+          SELECT 1 FROM hunt_units
+          WHERE hunt_units.state_id = ${state.id}
+            AND hunt_units.species_id = species.id
+        )`,
+      })
+      .from(species)
+      .where(
+        sql`EXISTS (
+          SELECT 1 FROM draw_odds
+          WHERE draw_odds.state_id = ${state.id}
+            AND draw_odds.species_id = species.id
+        ) OR EXISTS (
+          SELECT 1 FROM harvest_stats
+          WHERE harvest_stats.state_id = ${state.id}
+            AND harvest_stats.species_id = species.id
+        ) OR EXISTS (
+          SELECT 1 FROM seasons
+          WHERE seasons.state_id = ${state.id}
+            AND seasons.species_id = species.id
+        ) OR EXISTS (
+          SELECT 1 FROM hunt_units
+          WHERE hunt_units.state_id = ${state.id}
+            AND hunt_units.species_id = species.id
+        )`,
+      );
+
+    // Build the merged response. Curated entries win; derived-only species
+    // are appended with conservative defaults (hasDraw derived from
+    // draw_odds presence; everything else null/false).
+    const merged = [
+      ...curated.map((r) => ({
+        stateCode: r.stateCode,
+        stateName: r.stateName,
+        speciesSlug: r.speciesSlug,
+        speciesName: r.speciesName,
+        hasDraw: r.hasDraw,
+        hasOtc: r.hasOtc,
+        hasPoints: r.hasPoints,
+        pointType: r.pointType,
+        huntTypes: r.huntTypes,
+      })),
+      ...derived
+        .filter((r) => !curatedSpeciesIds.has(r.speciesId))
+        .map((r) => ({
+          stateCode: state.code,
+          stateName: state.name,
+          speciesSlug: r.speciesSlug,
+          speciesName: r.speciesName,
+          hasDraw: r.hasDrawData,
+          hasOtc: false,
+          hasPoints: false,
+          pointType: null as string | null,
+          huntTypes: [] as string[],
+        })),
+    ];
+
     return NextResponse.json({
       state: {
         code: state.code,
@@ -43,7 +122,7 @@ export async function GET(
         agencyName: state.agencyName,
         agencyUrl: state.agencyUrl,
       },
-      species: speciesData,
+      species: merged,
     });
   } catch (error) {
     console.error("[explore/states/detail] Error:", error);

--- a/src/app/api/v1/explore/states/route.ts
+++ b/src/app/api/v1/explore/states/route.ts
@@ -5,6 +5,12 @@ import { eq, sql } from "drizzle-orm";
 
 export async function GET() {
   try {
+    // speciesCount is a UNION across every table that ties species to a
+    // state, so the count reflects "do we have ANY data about this species
+    // in this state" rather than just the curated `state_species` metadata
+    // table. Without this, every state showed "0 species" in prod even when
+    // draw_odds / seasons / hunt_units had years of data — because
+    // state_species wasn't fully backfilled.
     const result = await db
       .select({
         id: states.id,
@@ -16,8 +22,17 @@ export async function GET() {
         agencyName: states.agencyName,
         agencyUrl: states.agencyUrl,
         speciesCount: sql<number>`(
-          SELECT count(*)::int FROM state_species
-          WHERE state_species.state_id = ${states.id}
+          SELECT count(DISTINCT species_id)::int FROM (
+            SELECT species_id FROM state_species WHERE state_id = ${states.id}
+            UNION
+            SELECT species_id FROM draw_odds WHERE state_id = ${states.id}
+            UNION
+            SELECT species_id FROM harvest_stats WHERE state_id = ${states.id}
+            UNION
+            SELECT species_id FROM seasons WHERE state_id = ${states.id}
+            UNION
+            SELECT species_id FROM hunt_units WHERE state_id = ${states.id}
+          ) all_species
         )`,
       })
       .from(states)

--- a/src/app/api/v1/profile/route.ts
+++ b/src/app/api/v1/profile/route.ts
@@ -27,10 +27,44 @@ export async function GET(request: NextRequest) {
 
     const profile = await getProfile(userId);
 
+    // ── Derived counters ───────────────────────────────────────────────────
+    // The profile page surfaces three quick-stat tiles (States Active,
+    // Species, Total Points). Previously they all read uninitialized fields
+    // on the API response and fell back to 0 / array.length. Compute them
+    // server-side so every consumer (dashboard, profile page, future
+    // widgets) gets consistent values.
+    const stateInterestPrefs = profile.preferences.filter(
+      (p) => p.category === "state_interest" && p.value !== false,
+    );
+    const speciesInterestPrefs = profile.preferences.filter(
+      (p) => p.category === "species_interest" && p.value !== false,
+    );
+    const pointHoldingStates = new Set(
+      profile.pointHoldings.map((h) => h.stateCode),
+    );
+    const stateInterestStates = new Set(stateInterestPrefs.map((p) => p.key));
+    const statesActive = new Set([
+      ...pointHoldingStates,
+      ...stateInterestStates,
+    ]).size;
+    const speciesTracked = speciesInterestPrefs.length;
+    const totalPoints = profile.pointHoldings.reduce(
+      (sum, h) => sum + (h.points ?? 0),
+      0,
+    );
+
     return NextResponse.json({
-      data: profile,
+      data: {
+        ...profile,
+        statesActive,
+        speciesTracked,
+        totalPoints,
+      },
       meta: {
         completeness: profile.completeness,
+        statesActive,
+        speciesTracked,
+        totalPoints,
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

UX walkthrough surfaced four bugs from one shared root cause: APIs returning fields the UI expected but never computed.

- **`/explore` → "0 species" on every state** (even CO/AZ with 22yr of draw_odds data). The query counted `state_species` rows, but that's a sparse curated metadata table. Replaced with a UNION across `state_species`, `draw_odds`, `harvest_stats`, `seasons`, `hunt_units`.
- **`/explore/[state]` drill-down empty** — same fix at the detail level; curated state_species wins, derived species (those with observational data) are appended with conservative defaults.
- **Profile "0 States Active"** — the field never existed on the API response. Now computed from `pointHoldings.stateCode` ∪ `state_interest` preferences.
- **Profile "0 Total Points"** — the most consequential bug: the page was reporting `pointHoldings.length` (a row count) instead of the sum of the actual `points` values. A user with 12 CO elk points + 5 NV mule deer points was seeing "2".

Server-side computation lands in `/api/v1/profile`; defensive client fallback updated to match the server logic so the page stays correct during deploy windows.

## Test plan

- [ ] `/explore` — every state with any data shows a non-zero species count
- [ ] Click a western state (CO/AZ/NV) — drill-down lists species with available draw_odds/seasons data
- [ ] `/profile` — "States Active" matches the number of distinct states in your point holdings + state interests
- [ ] `/profile` — "Total Points" matches the SUM of `points` across your holdings, not the count of rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)