### PR TITLE
feat(admin): chat observability — persistence, scoring, transcript browser

### DIFF
--- a/src/app/(dashboard)/admin/chat/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/chat/[id]/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import {
+  ArrowLeft,
+  ThumbsUp,
+  ThumbsDown,
+  Flag,
+  Clock,
+  Cpu,
+} from "lucide-react";
+
+interface AdminMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
+  feedbackRating: "up" | "down" | null;
+  feedbackReason: string | null;
+  flagged: boolean;
+  flaggedReason: string | null;
+  model: string | null;
+  latencyMs: number | null;
+  tokenCount: number | null;
+  contextSummary: string | null;
+}
+
+interface AdminSession {
+  id: string;
+  userId: string;
+  title: string | null;
+  messageCount: number;
+  createdAt: string;
+}
+
+export default function AdminChatDetailPage() {
+  const params = useParams();
+  const id = params?.id as string | undefined;
+  const [session, setSession] = useState<AdminSession | null>(null);
+  const [messages, setMessages] = useState<AdminMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/v1/admin/chat/sessions/${id}`);
+        if (res.status === 403) {
+          if (!cancelled) setForbidden(true);
+          return;
+        }
+        const json = await res.json();
+        if (cancelled) return;
+        setSession(json.session);
+        setMessages(json.messages ?? []);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (forbidden) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        Forbidden.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Link
+        href="/admin/chat"
+        className="inline-flex items-center gap-1 text-sm text-brand-sage hover:text-brand-forest"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to sessions
+      </Link>
+
+      {loading || !session ? (
+        <p className="text-sm text-brand-sage">Loading…</p>
+      ) : (
+        <>
+          <div>
+            <h1 className="text-xl font-bold text-brand-bark dark:text-brand-cream">
+              {session.title ?? "(no title)"}
+            </h1>
+            <p className="mt-0.5 text-xs text-brand-sage">
+              {messages.length} messages · user {session.userId.slice(0, 8)} ·
+              opened {new Date(session.createdAt).toLocaleString()}
+            </p>
+          </div>
+
+          <ol className="space-y-3">
+            {messages.map((m) => (
+              <li
+                key={m.id}
+                className={
+                  m.role === "user"
+                    ? "rounded-xl border border-brand-sage/15 bg-brand-sage/5 p-3 dark:bg-brand-sage/10"
+                    : "rounded-xl border border-brand-sage/15 bg-white p-3 dark:bg-brand-bark"
+                }
+              >
+                <div className="mb-1 flex items-center justify-between text-xs text-brand-sage">
+                  <span className="font-medium uppercase">
+                    {m.role === "user" ? "Hunter" : "Grizz"}
+                  </span>
+                  <span>{new Date(m.createdAt).toLocaleString()}</span>
+                </div>
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-bark dark:text-brand-cream">
+                  {m.content}
+                </p>
+                {m.role === "assistant" && (
+                  <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-brand-sage">
+                    {m.feedbackRating === "up" && (
+                      <span className="flex items-center gap-1 text-brand-forest">
+                        <ThumbsUp className="h-3 w-3" /> User thumbs-up
+                      </span>
+                    )}
+                    {m.feedbackRating === "down" && (
+                      <span className="flex items-center gap-1 text-red-600">
+                        <ThumbsDown className="h-3 w-3" /> User thumbs-down
+                      </span>
+                    )}
+                    {m.flagged && (
+                      <span className="flex items-center gap-1 text-amber-600">
+                        <Flag className="h-3 w-3" /> Flagged
+                        {m.flaggedReason ? ` · ${m.flaggedReason}` : ""}
+                      </span>
+                    )}
+                    {m.model && (
+                      <span className="flex items-center gap-1">
+                        <Cpu className="h-3 w-3" /> {m.model}
+                      </span>
+                    )}
+                    {m.latencyMs != null && (
+                      <span className="flex items-center gap-1">
+                        <Clock className="h-3 w-3" /> {m.latencyMs}ms
+                      </span>
+                    )}
+                    {m.tokenCount != null && (
+                      <span>~{m.tokenCount} tokens</span>
+                    )}
+                    {m.contextSummary && (
+                      <span className="text-brand-sage/60">{m.contextSummary}</span>
+                    )}
+                  </div>
+                )}
+                {m.feedbackReason && (
+                  <p className="mt-2 rounded bg-red-50 px-2 py-1.5 text-xs italic text-red-700 dark:bg-red-900/20 dark:text-red-400">
+                    User reason: {m.feedbackReason}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ol>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/chat/page.tsx
+++ b/src/app/(dashboard)/admin/chat/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  MessageSquare,
+  ThumbsUp,
+  ThumbsDown,
+  Flag,
+  TrendingUp,
+  ChevronRight,
+} from "lucide-react";
+
+interface AdminSession {
+  id: string;
+  userId: string;
+  title: string | null;
+  messageCount: number;
+  lastMessageAt: string | null;
+  createdAt: string;
+  thumbsUp: number;
+  thumbsDown: number;
+  flaggedCount: number;
+}
+
+interface TopQuestion {
+  key: string;
+  example: string;
+  count: number;
+}
+
+type Filter = "all" | "flagged" | "down" | "up";
+
+export default function AdminChatPage() {
+  const [sessions, setSessions] = useState<AdminSession[]>([]);
+  const [topQuestions, setTopQuestions] = useState<TopQuestion[]>([]);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [days, setDays] = useState(7);
+  const [loading, setLoading] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const qs = new URLSearchParams();
+        if (filter === "flagged") qs.set("flagged", "1");
+        else if (filter === "down") qs.set("rating", "down");
+        else if (filter === "up") qs.set("rating", "up");
+        const [sRes, qRes] = await Promise.all([
+          fetch(`/api/v1/admin/chat/sessions?${qs.toString()}`),
+          fetch(`/api/v1/admin/chat/top-questions?days=${days}`),
+        ]);
+        if (sRes.status === 403 || qRes.status === 403) {
+          if (!cancelled) setForbidden(true);
+          return;
+        }
+        const sJson = await sRes.json();
+        const qJson = await qRes.json();
+        if (cancelled) return;
+        setSessions(sJson.sessions ?? []);
+        setTopQuestions(qJson.top ?? []);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [filter, days]);
+
+  if (forbidden) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-brand-bark dark:text-brand-cream">
+          Admin
+        </h1>
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          You don&apos;t have admin access. Ask the owner to add your email to
+          the <code>ADMIN_EMAILS</code> env var.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-brand-bark dark:text-brand-cream">
+          Chat observability
+        </h1>
+        <p className="mt-1 text-sm text-brand-sage">
+          Transcript browser, scoring, and top-questions clustering.
+        </p>
+      </div>
+
+      {/* Top questions */}
+      <section className="rounded-xl border border-brand-sage/10 bg-white p-4 dark:border-brand-sage/20 dark:bg-brand-bark">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-brand-sunset" />
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-brand-sage">
+              Top questions
+            </h2>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            {[7, 14, 30].map((d) => (
+              <button
+                key={d}
+                onClick={() => setDays(d)}
+                className={
+                  d === days
+                    ? "rounded bg-brand-forest px-2 py-0.5 text-white"
+                    : "rounded px-2 py-0.5 text-brand-sage hover:text-brand-bark"
+                }
+              >
+                {d}d
+              </button>
+            ))}
+          </div>
+        </div>
+        {loading ? (
+          <p className="text-sm text-brand-sage">Loading…</p>
+        ) : topQuestions.length === 0 ? (
+          <p className="text-sm text-brand-sage">No user questions in this window yet.</p>
+        ) : (
+          <ol className="space-y-1.5">
+            {topQuestions.slice(0, 15).map((q) => (
+              <li
+                key={q.key}
+                className="flex items-start justify-between gap-3 rounded-lg px-2 py-1.5 hover:bg-brand-sage/5"
+              >
+                <span className="line-clamp-2 text-sm text-brand-bark dark:text-brand-cream">
+                  {q.example}
+                </span>
+                <span className="shrink-0 rounded-full bg-brand-sage/10 px-2 py-0.5 text-xs font-medium text-brand-sage">
+                  ×{q.count}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      {/* Sessions */}
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <MessageSquare className="h-4 w-4 text-brand-forest" />
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-brand-sage">
+              Recent sessions
+            </h2>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            {(
+              [
+                { v: "all", label: "All" },
+                { v: "flagged", label: "Flagged" },
+                { v: "down", label: "Negative" },
+                { v: "up", label: "Positive" },
+              ] as { v: Filter; label: string }[]
+            ).map((f) => (
+              <button
+                key={f.v}
+                onClick={() => setFilter(f.v)}
+                className={
+                  f.v === filter
+                    ? "rounded bg-brand-forest px-2 py-0.5 text-white"
+                    : "rounded px-2 py-0.5 text-brand-sage hover:text-brand-bark"
+                }
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        {loading ? (
+          <p className="text-sm text-brand-sage">Loading…</p>
+        ) : sessions.length === 0 ? (
+          <p className="text-sm text-brand-sage">
+            No sessions match this filter yet.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {sessions.map((s) => (
+              <li key={s.id}>
+                <Link
+                  href={`/admin/chat/${s.id}`}
+                  className="flex items-center justify-between gap-3 rounded-xl border border-brand-sage/10 bg-white px-4 py-3 transition-colors hover:bg-brand-sage/5 dark:border-brand-sage/20 dark:bg-brand-bark"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="line-clamp-1 text-sm font-medium text-brand-bark dark:text-brand-cream">
+                      {s.title ?? "(no title)"}
+                    </p>
+                    <p className="mt-0.5 text-[11px] text-brand-sage">
+                      {s.messageCount} msgs ·{" "}
+                      {s.lastMessageAt
+                        ? new Date(s.lastMessageAt).toLocaleString()
+                        : "—"}{" "}
+                      · user {s.userId.slice(0, 8)}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-3 text-xs">
+                    {s.thumbsUp > 0 && (
+                      <span className="flex items-center gap-0.5 text-brand-forest">
+                        <ThumbsUp className="h-3 w-3" />
+                        {s.thumbsUp}
+                      </span>
+                    )}
+                    {s.thumbsDown > 0 && (
+                      <span className="flex items-center gap-0.5 text-red-600">
+                        <ThumbsDown className="h-3 w-3" />
+                        {s.thumbsDown}
+                      </span>
+                    )}
+                    {s.flaggedCount > 0 && (
+                      <span className="flex items-center gap-0.5 text-amber-600">
+                        <Flag className="h-3 w-3" />
+                        {s.flaggedCount}
+                      </span>
+                    )}
+                    <ChevronRight className="h-4 w-4 text-brand-sage" />
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/v1/admin/chat/sessions/[id]/route.ts
+++ b/src/app/api/v1/admin/chat/sessions/[id]/route.ts
@@ -1,0 +1,42 @@
+// =============================================================================
+// GET /api/v1/admin/chat/sessions/[id]
+// =============================================================================
+// Full transcript for a single session — all messages + observability
+// metadata. Used by the admin drill-down view.
+// =============================================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { eq, asc } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { aiChatSessions, aiChatMessages } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth/is-admin";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const admin = await requireAdmin();
+  if (!admin.ok) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id: sessionId } = await params;
+
+  const [sessionRow] = await db
+    .select()
+    .from(aiChatSessions)
+    .where(eq(aiChatSessions.id, sessionId))
+    .limit(1);
+
+  if (!sessionRow) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const messages = await db
+    .select()
+    .from(aiChatMessages)
+    .where(eq(aiChatMessages.sessionId, sessionId))
+    .orderBy(asc(aiChatMessages.createdAt));
+
+  return NextResponse.json({ session: sessionRow, messages });
+}

--- a/src/app/api/v1/admin/chat/sessions/route.ts
+++ b/src/app/api/v1/admin/chat/sessions/route.ts
@@ -1,0 +1,72 @@
+// =============================================================================
+// GET /api/v1/admin/chat/sessions
+// =============================================================================
+// Paginated list of chat sessions for the admin transcript browser.
+// Supports a few cheap filters that read off the indexed columns we added
+// in migration 0101.
+// =============================================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { desc, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { aiChatSessions, aiChatMessages } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth/is-admin";
+
+export async function GET(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin.ok) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(100, parseInt(searchParams.get("limit") ?? "50", 10));
+  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+  // Filters: ?flagged=1, ?rating=down, ?model=anthropic-direct
+  const flaggedOnly = searchParams.get("flagged") === "1";
+  const rating = searchParams.get("rating"); // 'up' | 'down'
+
+  // Aggregate per-session metadata: feedback counts, flagged counts, models.
+  const rows = await db
+    .select({
+      id: aiChatSessions.id,
+      userId: aiChatSessions.userId,
+      title: aiChatSessions.title,
+      messageCount: aiChatSessions.messageCount,
+      lastMessageAt: aiChatSessions.lastMessageAt,
+      createdAt: aiChatSessions.createdAt,
+      thumbsUp: sql<number>`(
+        SELECT count(*)::int FROM ai_chat_messages
+        WHERE ai_chat_messages.session_id = ${aiChatSessions.id}
+          AND ai_chat_messages.feedback_rating = 'up'
+      )`,
+      thumbsDown: sql<number>`(
+        SELECT count(*)::int FROM ai_chat_messages
+        WHERE ai_chat_messages.session_id = ${aiChatSessions.id}
+          AND ai_chat_messages.feedback_rating = 'down'
+      )`,
+      flaggedCount: sql<number>`(
+        SELECT count(*)::int FROM ai_chat_messages
+        WHERE ai_chat_messages.session_id = ${aiChatSessions.id}
+          AND ai_chat_messages.flagged = true
+      )`,
+    })
+    .from(aiChatSessions)
+    .orderBy(desc(aiChatSessions.lastMessageAt))
+    .limit(limit)
+    .offset(offset);
+
+  let filtered = rows;
+  if (flaggedOnly) {
+    filtered = filtered.filter((r) => r.flaggedCount > 0);
+  }
+  if (rating === "down") {
+    filtered = filtered.filter((r) => r.thumbsDown > 0);
+  } else if (rating === "up") {
+    filtered = filtered.filter((r) => r.thumbsUp > 0);
+  }
+
+  void eq;
+  void aiChatMessages;
+
+  return NextResponse.json({ sessions: filtered, limit, offset });
+}

--- a/src/app/api/v1/admin/chat/sessions/route.ts
+++ b/src/app/api/v1/admin/chat/sessions/route.ts
@@ -4,12 +4,18 @@
 // Paginated list of chat sessions for the admin transcript browser.
 // Supports a few cheap filters that read off the indexed columns we added
 // in migration 0101.
+//
+// Filters are pushed into the SQL WHERE clause via EXISTS subqueries so
+// that pagination (limit/offset) operates on the already-filtered set.
+// Doing the filtering in JS after .limit() — the original implementation
+// — produced short/missing pages when filters were active (review feedback
+// PR #16).
 // =============================================================================
 
 import { NextRequest, NextResponse } from "next/server";
-import { desc, eq, sql } from "drizzle-orm";
+import { desc, sql, type SQL } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { aiChatSessions, aiChatMessages } from "@/lib/db/schema";
+import { aiChatSessions } from "@/lib/db/schema";
 import { requireAdmin } from "@/lib/auth/is-admin";
 
 export async function GET(request: NextRequest) {
@@ -21,12 +27,52 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const limit = Math.min(100, parseInt(searchParams.get("limit") ?? "50", 10));
   const offset = parseInt(searchParams.get("offset") ?? "0", 10);
-  // Filters: ?flagged=1, ?rating=down, ?model=anthropic-direct
+  // Filters: ?flagged=1, ?rating=up|down
   const flaggedOnly = searchParams.get("flagged") === "1";
-  const rating = searchParams.get("rating"); // 'up' | 'down'
+  const rating = searchParams.get("rating");
 
-  // Aggregate per-session metadata: feedback counts, flagged counts, models.
-  const rows = await db
+  // Build EXISTS subqueries for any active filters. Using EXISTS lets us
+  // keep the per-session count subqueries below as-is while still
+  // narrowing the parent set BEFORE limit/offset are applied.
+  const whereClauses: SQL[] = [];
+  if (flaggedOnly) {
+    whereClauses.push(
+      sql`EXISTS (
+        SELECT 1 FROM ai_chat_messages
+        WHERE ai_chat_messages.session_id = ${aiChatSessions.id}
+          AND ai_chat_messages.flagged = true
+      )`,
+    );
+  }
+  if (rating === "down") {
+    whereClauses.push(
+      sql`EXISTS (
+        SELECT 1 FROM ai_chat_messages
+        WHERE ai_chat_messages.session_id = ${aiChatSessions.id}
+          AND ai_chat_messages.feedback_rating = 'down'
+      )`,
+    );
+  } else if (rating === "up") {
+    whereClauses.push(
+      sql`EXISTS (
+        SELECT 1 FROM ai_chat_messages
+        WHERE ai_chat_messages.session_id = ${aiChatSessions.id}
+          AND ai_chat_messages.feedback_rating = 'up'
+      )`,
+    );
+  }
+
+  // Concatenate clauses with AND if multiple. Drizzle's `and()` would
+  // also work; we use a manual SQL chain because the clauses are already
+  // raw SQL fragments.
+  const combinedWhere: SQL | undefined =
+    whereClauses.length === 0
+      ? undefined
+      : whereClauses.length === 1
+        ? whereClauses[0]
+        : sql.join(whereClauses, sql` AND `);
+
+  const baseQuery = db
     .select({
       id: aiChatSessions.id,
       userId: aiChatSessions.userId,
@@ -51,22 +97,16 @@ export async function GET(request: NextRequest) {
       )`,
     })
     .from(aiChatSessions)
+    .$dynamic();
+
+  const filteredQuery = combinedWhere
+    ? baseQuery.where(combinedWhere)
+    : baseQuery;
+
+  const sessions = await filteredQuery
     .orderBy(desc(aiChatSessions.lastMessageAt))
     .limit(limit)
     .offset(offset);
 
-  let filtered = rows;
-  if (flaggedOnly) {
-    filtered = filtered.filter((r) => r.flaggedCount > 0);
-  }
-  if (rating === "down") {
-    filtered = filtered.filter((r) => r.thumbsDown > 0);
-  } else if (rating === "up") {
-    filtered = filtered.filter((r) => r.thumbsUp > 0);
-  }
-
-  void eq;
-  void aiChatMessages;
-
-  return NextResponse.json({ sessions: filtered, limit, offset });
+  return NextResponse.json({ sessions, limit, offset });
 }

--- a/src/app/api/v1/admin/chat/top-questions/route.ts
+++ b/src/app/api/v1/admin/chat/top-questions/route.ts
@@ -1,0 +1,66 @@
+// =============================================================================
+// GET /api/v1/admin/chat/top-questions
+// =============================================================================
+// Cheap top-questions aggregation — normalizes question text and counts
+// occurrences over a configurable lookback window. Not embedding-based
+// (yet); the substring-bucketing here is good enough to surface obvious
+// patterns and seed prompt-improvement work. A future PR can swap this
+// for an embedding-cluster pass using Gemini embeddings (we already have
+// the index in `documents.embedding`).
+// =============================================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { eq, gte, and, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { aiChatMessages } from "@/lib/db/schema";
+import { requireAdmin } from "@/lib/auth/is-admin";
+
+export async function GET(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin.ok) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const days = Math.min(90, parseInt(searchParams.get("days") ?? "7", 10));
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  const rows = await db
+    .select({ content: aiChatMessages.content })
+    .from(aiChatMessages)
+    .where(
+      and(
+        eq(aiChatMessages.role, "user"),
+        gte(aiChatMessages.createdAt, since),
+      ),
+    );
+
+  // Normalize: lowercase, strip punctuation, collapse whitespace, drop
+  // very short questions (single words rarely cluster meaningfully).
+  const buckets = new Map<string, { example: string; count: number }>();
+  for (const r of rows) {
+    const text = r.content.trim();
+    if (text.length < 12) continue;
+    const norm = text
+      .toLowerCase()
+      .replace(/[^\w\s]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 80);
+    if (norm.length < 8) continue;
+    const existing = buckets.get(norm);
+    if (existing) {
+      existing.count++;
+    } else {
+      buckets.set(norm, { example: text, count: 1 });
+    }
+  }
+
+  const top = Array.from(buckets.entries())
+    .map(([norm, v]) => ({ key: norm, example: v.example, count: v.count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 50);
+
+  void sql;
+  return NextResponse.json({ window_days: days, top });
+}

--- a/src/app/api/v1/chat/messages/[id]/feedback/route.ts
+++ b/src/app/api/v1/chat/messages/[id]/feedback/route.ts
@@ -1,0 +1,97 @@
+// =============================================================================
+// POST /api/v1/chat/messages/[id]/feedback
+// =============================================================================
+// Records a user's thumbs-up / thumbs-down (+ optional free-text reason) on
+// a previously-persisted assistant chat message. The signed-in user must
+// own the parent session — no cross-user rating.
+// =============================================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { aiChatMessages, aiChatSessions } from "@/lib/db/schema";
+
+interface FeedbackBody {
+  rating: "up" | "down";
+  reason?: string | null;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: messageId } = await params;
+  if (!messageId) {
+    return NextResponse.json({ error: "messageId is required" }, { status: 400 });
+  }
+
+  let body: FeedbackBody;
+  try {
+    body = (await request.json()) as FeedbackBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (body.rating !== "up" && body.rating !== "down") {
+    return NextResponse.json(
+      { error: "rating must be 'up' or 'down'" },
+      { status: 400 },
+    );
+  }
+
+  // Look up the message and verify the user owns its session.
+  const [msg] = await db
+    .select({
+      messageId: aiChatMessages.id,
+      sessionId: aiChatMessages.sessionId,
+      role: aiChatMessages.role,
+      ownerUserId: aiChatSessions.userId,
+    })
+    .from(aiChatMessages)
+    .innerJoin(
+      aiChatSessions,
+      eq(aiChatMessages.sessionId, aiChatSessions.id),
+    )
+    .where(eq(aiChatMessages.id, messageId))
+    .limit(1);
+
+  if (!msg) {
+    return NextResponse.json({ error: "Message not found" }, { status: 404 });
+  }
+  if (msg.ownerUserId !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (msg.role !== "assistant") {
+    return NextResponse.json(
+      { error: "Only assistant messages can be rated" },
+      { status: 400 },
+    );
+  }
+
+  // Trim and length-cap the reason text — keep DB rows lean.
+  const reasonClean =
+    typeof body.reason === "string"
+      ? body.reason.trim().slice(0, 500) || null
+      : null;
+
+  await db
+    .update(aiChatMessages)
+    .set({
+      feedbackRating: body.rating,
+      feedbackReason: reasonClean,
+      feedbackAt: new Date(),
+      // Auto-flag thumbs-down messages for the ops review queue so they
+      // surface even without an explicit ops action.
+      flagged: body.rating === "down" ? true : undefined,
+      flaggedReason: body.rating === "down" ? "user_thumbs_down" : undefined,
+    })
+    .where(eq(aiChatMessages.id, messageId));
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/v1/chat/route.ts
+++ b/src/app/api/v1/chat/route.ts
@@ -9,7 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { eq, and } from "drizzle-orm";
+import { eq, and, gte, desc } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   hunterPreferences,
@@ -19,6 +19,8 @@ import {
   states,
   species,
   huntUnits,
+  aiChatSessions,
+  aiChatMessages,
 } from "@/lib/db/schema";
 import { config } from "@/lib/config";
 import { assembleContext } from "@/lib/ai/rag";
@@ -121,37 +123,39 @@ export async function POST(request: NextRequest) {
 
   const fullMessage = messageParts.join("\n\n");
 
-  // Try OpenClaw gateway first, then fall back to Anthropic, Gemini, and OpenAI
+  // Try OpenClaw gateway first, then fall back to Anthropic, Gemini, and OpenAI.
+  // Each attempt's outcome (success or failure + model used + latency) is
+  // captured here so admin observability has accurate per-message metadata.
+  const t0 = Date.now();
+  let reply: string;
+  let modelUsed: string;
   try {
-    const reply = await callOpenClawGateway(fullMessage);
-    return NextResponse.json({ text: reply });
+    reply = await callOpenClawGateway(fullMessage);
+    modelUsed = "openclaw-gateway";
   } catch (gatewayErr) {
     console.warn(
       "[chat] OpenClaw gateway unavailable, trying direct providers:",
       gatewayErr instanceof Error ? gatewayErr.message : String(gatewayErr)
     );
-
     try {
-      const reply = await callAnthropicDirect(fullMessage);
-      return NextResponse.json({ text: reply });
+      reply = await callAnthropicDirect(fullMessage);
+      modelUsed = "anthropic-direct";
     } catch (anthropicErr) {
       console.warn(
         "[chat] Anthropic unavailable, trying Gemini:",
         anthropicErr instanceof Error ? anthropicErr.message : String(anthropicErr)
       );
-
       try {
-        const reply = await callGeminiDirect(fullMessage);
-        return NextResponse.json({ text: reply });
+        reply = await callGeminiDirect(fullMessage);
+        modelUsed = "gemini-direct";
       } catch (geminiErr) {
         console.warn(
           "[chat] Gemini unavailable, trying OpenAI:",
           geminiErr instanceof Error ? geminiErr.message : String(geminiErr)
         );
-
         try {
-          const reply = await callOpenAIDirect(fullMessage);
-          return NextResponse.json({ text: reply });
+          reply = await callOpenAIDirect(fullMessage);
+          modelUsed = "openai-direct";
         } catch (openaiErr) {
           console.error("[chat] All backends failed:", openaiErr);
           return NextResponse.json(
@@ -162,6 +166,144 @@ export async function POST(request: NextRequest) {
       }
     }
   }
+  const latencyMs = Date.now() - t0;
+
+  // Persist the exchange so the admin observability dashboard has data to
+  // browse, score, and cluster on. Best-effort — never block the response
+  // on a persistence failure.
+  let assistantMessageId: string | null = null;
+  try {
+    const persisted = await persistChatExchange({
+      userId: session.user.id,
+      userMessage: trimmedMessage,
+      assistantReply: reply,
+      model: modelUsed,
+      latencyMs,
+      contextSummary: summarizeContext({ profileContext, groundingContext }),
+    });
+    assistantMessageId = persisted.assistantMessageId;
+  } catch (persistErr) {
+    console.error("[chat] persistence failed:", persistErr);
+  }
+
+  return NextResponse.json({
+    text: reply,
+    messageId: assistantMessageId,
+  });
+}
+
+// =============================================================================
+// Persistence helpers — wired into POST above
+// =============================================================================
+
+/**
+ * Find the most recent open session for this user (within the last
+ * SESSION_WINDOW_MS) and append to it; otherwise create a new session.
+ * Returns the assistant message id so the client can submit feedback on it.
+ */
+async function persistChatExchange(opts: {
+  userId: string;
+  userMessage: string;
+  assistantReply: string;
+  model: string;
+  latencyMs: number;
+  contextSummary: string | null;
+}): Promise<{ sessionId: string; assistantMessageId: string }> {
+  const SESSION_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+  const cutoff = new Date(Date.now() - SESSION_WINDOW_MS);
+
+  const [existing] = await db
+    .select()
+    .from(aiChatSessions)
+    .where(
+      and(
+        eq(aiChatSessions.userId, opts.userId),
+        gte(aiChatSessions.lastMessageAt, cutoff),
+      ),
+    )
+    .orderBy(desc(aiChatSessions.lastMessageAt))
+    .limit(1);
+
+  const titleFromFirstQuestion = opts.userMessage.slice(0, 120);
+
+  let sessionId: string;
+  if (existing) {
+    sessionId = existing.id;
+    await db
+      .update(aiChatSessions)
+      .set({
+        messageCount: existing.messageCount + 2,
+        lastMessageAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(aiChatSessions.id, existing.id));
+  } else {
+    const [created] = await db
+      .insert(aiChatSessions)
+      .values({
+        userId: opts.userId,
+        title: titleFromFirstQuestion,
+        messageCount: 2,
+        lastMessageAt: new Date(),
+      })
+      .returning();
+    if (!created) throw new Error("Failed to create chat session");
+    sessionId = created.id;
+  }
+
+  // Insert the user message followed by the assistant reply
+  await db.insert(aiChatMessages).values({
+    sessionId,
+    role: "user",
+    content: opts.userMessage,
+  });
+
+  const [assistantRow] = await db
+    .insert(aiChatMessages)
+    .values({
+      sessionId,
+      role: "assistant",
+      content: opts.assistantReply,
+      model: opts.model,
+      latencyMs: opts.latencyMs,
+      tokenCount: estimateTokens(opts.assistantReply),
+      contextSummary: opts.contextSummary,
+      // Simple auto-flag heuristics. We don't pretend these are accurate —
+      // they just route low-quality answers to a review queue.
+      flagged:
+        opts.assistantReply.length < 60 ||
+        /try messaging him on telegram/i.test(opts.assistantReply),
+      flaggedReason:
+        opts.assistantReply.length < 60
+          ? "very_short_response"
+          : /try messaging him on telegram/i.test(opts.assistantReply)
+            ? "fallback_response"
+            : null,
+    })
+    .returning();
+
+  if (!assistantRow) throw new Error("Failed to insert assistant message");
+  return { sessionId, assistantMessageId: assistantRow.id };
+}
+
+function estimateTokens(text: string): number {
+  // Rough heuristic: ~4 chars per token. Good enough for trends without
+  // a tokenizer dependency.
+  return Math.ceil(text.length / 4);
+}
+
+function summarizeContext(opts: {
+  profileContext: string | null;
+  groundingContext: string | null;
+}): string | null {
+  const bits: string[] = [];
+  if (opts.profileContext) {
+    bits.push(`profile(${opts.profileContext.length}c)`);
+  }
+  if (opts.groundingContext) {
+    bits.push(`grounding(${opts.groundingContext.length}c)`);
+  }
+  return bits.length > 0 ? bits.join(" + ") : null;
 }
 
 // =============================================================================

--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -8,10 +8,14 @@ interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
+  // Server-issued id once the message lands in ai_chat_messages — required
+  // for the inline feedback control.
+  serverMessageId?: string | null;
 }
 
 interface ChatResponse {
   text?: string;
+  messageId?: string | null;
 }
 
 const aiName = process.env.NEXT_PUBLIC_AI_ASSISTANT_NAME || "Grizz";
@@ -78,7 +82,9 @@ export function ChatContainer() {
           );
         }
 
-        // Update assistant message with Grizz's response
+        // Update assistant message with the response — and capture the
+        // server-issued messageId so inline feedback controls have a
+        // persisted row to attach to.
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId
@@ -88,6 +94,8 @@ export function ChatContainer() {
                     data && "text" in data && data.text
                       ? data.text
                       : "Sorry, I didn't get a response.",
+                  serverMessageId:
+                    data && "messageId" in data ? data.messageId ?? null : null,
                 }
               : m,
           ),
@@ -157,6 +165,7 @@ export function ChatContainer() {
               msg.id === messages[messages.length - 1]?.id &&
               msg.role === "assistant"
             }
+            messageId={msg.serverMessageId}
           />
         ))}
         <div ref={bottomRef} />

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,19 +1,22 @@
 "use client";
 
-import { memo, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { User } from "lucide-react";
+import { User, ThumbsUp, ThumbsDown, Check } from "lucide-react";
 
 interface ChatMessageProps {
   role: "user" | "assistant";
   content: string;
   isStreaming?: boolean;
+  /** Persisted message id — when present, enables inline feedback controls. */
+  messageId?: string | null;
 }
 
 export const ChatMessage = memo(function ChatMessage({
   role,
   content,
   isStreaming,
+  messageId,
 }: ChatMessageProps) {
   const isUser = role === "user";
 
@@ -54,12 +57,128 @@ export const ChatMessage = memo(function ChatMessage({
         ) : (
           <div className="space-y-3">
             {renderAssistantContent(content, isStreaming)}
+            {/* Inline feedback — only after the message has streamed in and
+               we have a persisted id to attach feedback to. */}
+            {!isStreaming && messageId && content.trim().length > 0 && (
+              <MessageFeedback messageId={messageId} />
+            )}
           </div>
         )}
       </div>
     </div>
   );
 });
+
+// =============================================================================
+// Inline feedback — 👍 / 👎 with optional free-text reason capture
+// =============================================================================
+
+function MessageFeedback({ messageId }: { messageId: string }) {
+  const [rating, setRating] = useState<"up" | "down" | null>(null);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [showReason, setShowReason] = useState(false);
+
+  const submit = async (next: "up" | "down", withReason?: string) => {
+    if (submitting) return;
+    setRating(next);
+    setSubmitting(true);
+    try {
+      await fetch(`/api/v1/chat/messages/${messageId}/feedback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          rating: next,
+          reason: withReason ?? null,
+        }),
+      });
+      if (next === "up") {
+        setDone(true);
+      } else {
+        // For thumbs-down we ask why
+        setShowReason(true);
+      }
+    } catch (err) {
+      console.error("[chat:feedback] failed:", err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <p className="flex items-center gap-1 text-xs text-brand-sage">
+        <Check className="h-3.5 w-3.5" />
+        Thanks — feedback recorded.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => submit("up")}
+          disabled={submitting || rating !== null}
+          aria-label="Helpful"
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-md border border-brand-sage/20 text-brand-sage transition-colors hover:bg-brand-sage/10 disabled:opacity-50",
+            rating === "up" && "bg-brand-forest/10 text-brand-forest",
+          )}
+        >
+          <ThumbsUp className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => submit("down")}
+          disabled={submitting || rating !== null}
+          aria-label="Not helpful"
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-md border border-brand-sage/20 text-brand-sage transition-colors hover:bg-brand-sage/10 disabled:opacity-50",
+            rating === "down" && "bg-red-50 text-red-600",
+          )}
+        >
+          <ThumbsDown className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {showReason && rating === "down" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit("down", reason);
+            setDone(true);
+          }}
+          className="flex flex-col gap-2"
+        >
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value.slice(0, 500))}
+            placeholder="What was wrong? (optional)"
+            rows={2}
+            className="resize-none rounded-md border border-brand-sage/20 bg-white/80 px-2 py-1 text-xs text-brand-bark placeholder:text-brand-sage/50 focus:border-brand-forest focus:outline-none focus:ring-1 focus:ring-brand-forest/30 dark:bg-brand-bark/50 dark:text-brand-cream"
+          />
+          <div className="flex items-center gap-2">
+            <button
+              type="submit"
+              className="rounded-md bg-brand-forest px-2 py-1 text-xs font-medium text-white hover:bg-brand-forest/90"
+            >
+              Send
+            </button>
+            <button
+              type="button"
+              onClick={() => setDone(true)}
+              className="text-xs text-brand-sage hover:text-brand-bark"
+            >
+              Skip
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
 
 function renderAssistantContent(
   content: string,

--- a/src/lib/auth/is-admin.ts
+++ b/src/lib/auth/is-admin.ts
@@ -1,0 +1,65 @@
+// =============================================================================
+// Admin Access Helper
+// =============================================================================
+// Until we wire a proper role table, admin access is gated by a simple
+// allow-list of email addresses provided via the ADMIN_EMAILS env var
+// (comma-separated). This keeps the surface area minimal and reversible —
+// no schema changes, no UI for granting roles, no migration to undo.
+//
+// To make Mitch an admin in prod, set:
+//   ADMIN_EMAILS=mitch@huntlogic.ai,mitch@recademics.com
+// in Vercel project settings.
+//
+// In dev with no env var set, the helper falls back to allowing any user
+// with an email matching the configured support email — so local
+// development still works.
+// =============================================================================
+
+import { auth } from "@/lib/auth";
+
+export interface AdminCheckResult {
+  ok: boolean;
+  userId?: string;
+  email?: string;
+}
+
+export function getAdminEmails(): string[] {
+  const raw = process.env.ADMIN_EMAILS ?? "";
+  return raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Resolve the current session and check whether its email is in the admin
+ * allow-list. Returns `ok: false` for unauthenticated or non-admin users.
+ */
+export async function requireAdmin(): Promise<AdminCheckResult> {
+  const session = await auth();
+  const email = session?.user?.email?.toLowerCase();
+  const userId = session?.user?.id;
+
+  if (!email || !userId) {
+    return { ok: false };
+  }
+
+  const allowList = getAdminEmails();
+
+  // Dev fallback: if the allow-list is empty, accept the support-email
+  // address as a safety hatch so local dev isn't locked out before the
+  // env var is set.
+  if (allowList.length === 0) {
+    const supportEmail = (process.env.SUPPORT_EMAIL ?? "").toLowerCase();
+    if (supportEmail && email === supportEmail) {
+      return { ok: true, userId, email };
+    }
+    return { ok: false, userId, email };
+  }
+
+  return {
+    ok: allowList.includes(email),
+    userId,
+    email,
+  };
+}

--- a/src/lib/db/migrations/0101_chat_observability.sql
+++ b/src/lib/db/migrations/0101_chat_observability.sql
@@ -1,0 +1,40 @@
+-- =============================================================================
+-- Migration 0101 — Chat Observability
+-- =============================================================================
+-- Adds feedback + telemetry columns to ai_chat_messages so the admin
+-- observability dashboard has something to score.
+--
+-- All additive. Existing rows get NULL for the new fields, which the
+-- application treats as "no feedback recorded yet."
+-- =============================================================================
+
+ALTER TABLE ai_chat_messages
+  ADD COLUMN IF NOT EXISTS feedback_rating TEXT,         -- 'up' | 'down' | NULL
+  ADD COLUMN IF NOT EXISTS feedback_reason TEXT,          -- free-text from user
+  ADD COLUMN IF NOT EXISTS feedback_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS flagged BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS flagged_reason TEXT,           -- ops note / auto-flag heuristic
+  ADD COLUMN IF NOT EXISTS model TEXT,                    -- 'claude-sonnet-4', 'gemini-1.5', etc.
+  ADD COLUMN IF NOT EXISTS latency_ms INTEGER,            -- generation latency
+  ADD COLUMN IF NOT EXISTS token_count INTEGER,           -- approx output tokens
+  ADD COLUMN IF NOT EXISTS prompt_version TEXT,           -- A/B testing harness hook
+  ADD COLUMN IF NOT EXISTS context_summary TEXT;          -- short blurb of what RAG/grounding loaded
+
+CREATE INDEX IF NOT EXISTS ai_chat_messages_feedback_rating_idx
+  ON ai_chat_messages(feedback_rating);
+CREATE INDEX IF NOT EXISTS ai_chat_messages_flagged_idx
+  ON ai_chat_messages(flagged);
+CREATE INDEX IF NOT EXISTS ai_chat_messages_model_idx
+  ON ai_chat_messages(model);
+CREATE INDEX IF NOT EXISTS ai_chat_messages_created_at_idx
+  ON ai_chat_messages(created_at);
+
+-- Session-level title cache so the admin transcript browser can render a
+-- short summary (first user message snippet) without re-querying messages.
+ALTER TABLE ai_chat_sessions
+  ADD COLUMN IF NOT EXISTS title TEXT,
+  ADD COLUMN IF NOT EXISTS message_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_message_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS ai_chat_sessions_last_message_at_idx
+  ON ai_chat_sessions(last_message_at);

--- a/src/lib/db/schema/ai-chat.ts
+++ b/src/lib/db/schema/ai-chat.ts
@@ -5,6 +5,8 @@ import {
   text,
   timestamp,
   jsonb,
+  integer,
+  boolean,
   index,
 } from "drizzle-orm/pg-core";
 
@@ -18,6 +20,11 @@ export const aiChatSessions = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     userId: text("user_id").notNull(),
     unitId: text("unit_id"),
+    // Short summary so the admin transcript browser can render a list
+    // without re-querying messages. Derived from the first user message.
+    title: text("title"),
+    messageCount: integer("message_count").notNull().default(0),
+    lastMessageAt: timestamp("last_message_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -27,6 +34,7 @@ export const aiChatSessions = pgTable(
   },
   (table) => [
     index("ai_chat_sessions_user_id_idx").on(table.userId),
+    index("ai_chat_sessions_last_message_at_idx").on(table.lastMessageAt),
   ]
 );
 
@@ -44,12 +52,27 @@ export const aiChatMessages = pgTable(
     role: text("role").notNull(), // 'user' | 'assistant'
     content: text("content").notNull(),
     citations: jsonb("citations"),
+    // ── Observability columns (added 2026-05) ───────────────────────────────
+    feedbackRating: text("feedback_rating"), // 'up' | 'down' | null
+    feedbackReason: text("feedback_reason"),
+    feedbackAt: timestamp("feedback_at", { withTimezone: true }),
+    flagged: boolean("flagged").notNull().default(false),
+    flaggedReason: text("flagged_reason"),
+    model: text("model"), // 'claude-sonnet-4', 'gemini-1.5', etc.
+    latencyMs: integer("latency_ms"),
+    tokenCount: integer("token_count"),
+    promptVersion: text("prompt_version"), // A/B testing harness hook
+    contextSummary: text("context_summary"), // short blurb of grounding context
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
   },
   (table) => [
     index("ai_chat_messages_session_id_idx").on(table.sessionId),
+    index("ai_chat_messages_feedback_rating_idx").on(table.feedbackRating),
+    index("ai_chat_messages_flagged_idx").on(table.flagged),
+    index("ai_chat_messages_model_idx").on(table.model),
+    index("ai_chat_messages_created_at_idx").on(table.createdAt),
   ]
 );
 


### PR DESCRIPTION
## Summary

Mitch asked for an admin way to see what people are asking + score model responses → train over time. Found the chat endpoint was talking to four providers but writing **nothing** to `ai_chat_sessions` / `ai_chat_messages`. This PR closes that loop end-to-end.

## What ships

**Schema additions** (migration 0101, additive):
- `ai_chat_sessions`: `title`, `message_count`, `last_message_at`
- `ai_chat_messages`: `feedback_rating`, `feedback_reason`, `feedback_at`, `flagged`, `flagged_reason`, `model`, `latency_ms`, `token_count`, `prompt_version`, `context_summary`

**Chat backend now persists each exchange**:
- 30-minute session-extension window (group conversation turns)
- Captures model used, latency, token estimate, context summary
- Auto-flags very-short / fallback responses for the review queue
- Response shape gains `messageId` so the UI can attach feedback

**User-facing feedback**:
- Inline 👍 / 👎 buttons under every persisted assistant message
- Thumbs-down opens a small free-text reason form
- `POST /api/v1/chat/messages/[id]/feedback` records + auto-flags

**Admin pages** (gated by `ADMIN_EMAILS` env var):
- `/admin/chat` — top questions (7/14/30d), filterable session list
- `/admin/chat/[id]` — full transcript with per-message metadata (rating, flag, model, latency, tokens, context summary)

**Admin APIs**:
- `GET /api/v1/admin/chat/sessions` (paginated, filtered by All / Flagged / Negative / Positive)
- `GET /api/v1/admin/chat/sessions/[id]` (full transcript)
- `GET /api/v1/admin/chat/top-questions?days=N` (substring bucketing — embedding-cluster upgrade is a follow-up)
- `src/lib/auth/is-admin.ts` (ADMIN_EMAILS allow-list with dev fallback)

## Apply order for prod

```bash
psql $DATABASE_URL -f src/lib/db/migrations/0101_chat_observability.sql
# Set ADMIN_EMAILS=mitch@huntlogic.ai (or whatever email you sign in with) in Vercel
# Deploy
```

## Test plan

- [ ] Migration applies cleanly
- [ ] Send a chat message → confirm a row appears in `ai_chat_messages` with model + latency
- [ ] Thumbs-up / thumbs-down on a response → confirm feedback persisted
- [ ] Set `ADMIN_EMAILS` to your email, visit `/admin/chat` → see your test session
- [ ] Click into the session → see full transcript with metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)