### PR TITLE
feat(dashboard): "what can I hunt this weekend?" activation widget

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { StrategySnapshot } from "@/components/dashboard/StrategySnapshot";
 import { DeadlineWidget } from "@/components/dashboard/DeadlineWidget";
 import { ActionFeed } from "@/components/dashboard/ActionFeed";
 import { WhatChanged } from "@/components/dashboard/WhatChanged";
+import { ThisWeekendWidget } from "@/components/dashboard/ThisWeekendWidget";
 import { SkeletonList } from "@/components/ui/Skeleton";
 import { apiClient } from "@/lib/api/client";
 
@@ -186,6 +187,11 @@ export default function DashboardPage() {
 
       {/* Concierge chat — Mitch April 30 review #2: chat as a core dashboard feature. */}
       <ConciergeChatCard userName={data.userName} />
+
+      {/* "What can I hunt this weekend?" — activation widget that surfaces
+         OTC + open-season opportunities near the user's home state. Self-
+         hides when there's nothing to show. */}
+      <ThisWeekendWidget />
 
       {/* What Changed */}
       <WhatChanged />

--- a/src/app/api/v1/dashboard/this-weekend/route.ts
+++ b/src/app/api/v1/dashboard/this-weekend/route.ts
@@ -1,0 +1,212 @@
+// =============================================================================
+// GET /api/v1/dashboard/this-weekend
+// =============================================================================
+// "What can I hunt this weekend?" — surfaces OTC + open-season hunts near the
+// user's home state for the upcoming weekend (today + next 3 days). Used by
+// the dashboard activation widget.
+//
+// Data sources (in order of preference):
+//   1. seasons table — for season_start <= today + 7d AND season_end >= today
+//   2. state_species table — to flag OTC vs draw
+//   3. user profile — to filter to user's home state + neighbors
+//
+// We deliberately return a small number (5) and keep the response light;
+// the widget is meant to be glanceable, not browsable.
+// =============================================================================
+
+import { NextResponse } from "next/server";
+import { and, eq, sql, gte, lte, or } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import {
+  seasons,
+  states,
+  species,
+  stateSpecies,
+  huntUnits,
+} from "@/lib/db/schema";
+import { getProfile } from "@/services/profile";
+
+interface WeekendOpportunity {
+  stateCode: string;
+  stateName: string;
+  speciesSlug: string;
+  speciesName: string;
+  seasonName: string | null;
+  weaponType: string | null;
+  tagType: "draw" | "otc" | "leftover" | "unknown";
+  seasonStart: string | null;
+  seasonEnd: string | null;
+  daysRemaining: number | null;
+  isHomeState: boolean;
+  isOtc: boolean;
+  publicLandPct: number | null;
+  // Why we picked this: short rationale string for the card subtitle.
+  rationale: string;
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Compute the "this weekend" window: today through 7 days out.
+  const today = new Date();
+  const todayIso = today.toISOString().split("T")[0]!;
+  const sevenDaysOut = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split("T")[0]!;
+
+  // Load the user's profile to learn home state.
+  let homeStateCode: string | null = null;
+  try {
+    const profile = await getProfile(session.user.id);
+    const homePref = profile.preferences.find(
+      (p) => p.category === "location" && p.key === "home_state",
+    );
+    if (typeof homePref?.value === "string") {
+      homeStateCode = homePref.value.toUpperCase();
+    }
+  } catch (err) {
+    console.warn("[this-weekend] profile load failed (continuing):", err);
+  }
+
+  // Pull active or imminent seasons.
+  const rows = await db
+    .select({
+      seasonId: seasons.id,
+      seasonName: seasons.seasonName,
+      weaponType: seasons.weaponType,
+      tagType: seasons.tagType,
+      seasonStart: seasons.startDate,
+      seasonEnd: seasons.endDate,
+      stateCode: states.code,
+      stateName: states.name,
+      speciesSlug: species.slug,
+      speciesName: species.commonName,
+      isOtc: stateSpecies.hasOtc,
+      publicLandPct: huntUnits.publicLandPct,
+    })
+    .from(seasons)
+    .innerJoin(states, eq(seasons.stateId, states.id))
+    .innerJoin(species, eq(seasons.speciesId, species.id))
+    // state_species is sometimes-sparse — leftJoin so we still get rows even
+    // when the metadata table hasn't been seeded for this combination.
+    .leftJoin(
+      stateSpecies,
+      and(
+        eq(stateSpecies.stateId, seasons.stateId),
+        eq(stateSpecies.speciesId, seasons.speciesId),
+      ),
+    )
+    .leftJoin(huntUnits, eq(seasons.huntUnitId, huntUnits.id))
+    .where(
+      and(
+        // Open right now: start <= today + 7d AND end >= today.
+        lte(seasons.startDate, sevenDaysOut),
+        gte(seasons.endDate, todayIso),
+        // Prefer OTC for the "this weekend" use case — these are
+        // hunts a hunter can actually go on without a draw cycle.
+        // We still keep general/leftover; just down-rank pure-draw.
+        or(
+          eq(seasons.tagType, "otc"),
+          eq(seasons.tagType, "leftover"),
+          // Allow draw too — many states call general-season "draw"
+          // even when nonresidents can buy over-the-counter equivalents.
+          sql`${seasons.tagType} IS NULL OR ${seasons.tagType} = 'draw'`,
+        ),
+      ),
+    )
+    .limit(60);
+
+  // Score + dedupe at the (state, species, season_name) level.
+  type Scored = WeekendOpportunity & { _score: number; _key: string };
+  const seen = new Map<string, Scored>();
+
+  for (const r of rows) {
+    const isHomeState =
+      !!homeStateCode && r.stateCode.toUpperCase() === homeStateCode;
+    const isOtc = !!r.isOtc || r.tagType === "otc" || r.tagType === "leftover";
+    const endDate = r.seasonEnd ? new Date(r.seasonEnd) : null;
+    const startDate = r.seasonStart ? new Date(r.seasonStart) : null;
+    const daysRemaining = endDate
+      ? Math.max(
+          0,
+          Math.ceil(
+            (endDate.getTime() - today.getTime()) / (24 * 60 * 60 * 1000),
+          ),
+        )
+      : null;
+    const daysUntilStart = startDate
+      ? Math.max(
+          0,
+          Math.ceil(
+            (startDate.getTime() - today.getTime()) / (24 * 60 * 60 * 1000),
+          ),
+        )
+      : null;
+
+    // Score: home state +50, OTC +30, season already open +15, recent
+    // public land bonus, longer remaining window +10.
+    let score = 0;
+    if (isHomeState) score += 50;
+    if (isOtc) score += 30;
+    if (daysUntilStart === 0) score += 15;
+    if ((r.publicLandPct ?? 0) >= 50) score += 10;
+    if ((daysRemaining ?? 0) >= 30) score += 5;
+
+    // Rationale string for the card subtitle.
+    const rationaleBits: string[] = [];
+    if (isHomeState) rationaleBits.push("in your home state");
+    if (isOtc) rationaleBits.push("OTC");
+    if (daysUntilStart === 0 && daysRemaining !== null)
+      rationaleBits.push(`open now, ${daysRemaining}d left`);
+    else if (daysUntilStart !== null && daysUntilStart > 0)
+      rationaleBits.push(`opens in ${daysUntilStart}d`);
+    if ((r.publicLandPct ?? 0) >= 50)
+      rationaleBits.push(`${Math.round(r.publicLandPct ?? 0)}% public land`);
+    const rationale =
+      rationaleBits.length > 0 ? rationaleBits.join(" · ") : "Season open";
+
+    const key = `${r.stateCode}|${r.speciesSlug}|${r.seasonName ?? ""}`;
+    const candidate: Scored = {
+      _score: score,
+      _key: key,
+      stateCode: r.stateCode,
+      stateName: r.stateName,
+      speciesSlug: r.speciesSlug,
+      speciesName: r.speciesName,
+      seasonName: r.seasonName,
+      weaponType: r.weaponType,
+      tagType: ((r.tagType as WeekendOpportunity["tagType"]) ?? "unknown"),
+      seasonStart: r.seasonStart,
+      seasonEnd: r.seasonEnd,
+      daysRemaining,
+      isHomeState,
+      isOtc,
+      publicLandPct: r.publicLandPct ?? null,
+      rationale,
+    };
+
+    const existing = seen.get(key);
+    if (!existing || candidate._score > existing._score) {
+      seen.set(key, candidate);
+    }
+  }
+
+  const ranked = Array.from(seen.values())
+    .sort((a, b) => b._score - a._score)
+    .slice(0, 5)
+    .map(({ _score: _s, _key: _k, ...rest }) => {
+      void _s;
+      void _k;
+      return rest as WeekendOpportunity;
+    });
+
+  return NextResponse.json({
+    opportunities: ranked,
+    homeState: homeStateCode,
+    window: { from: todayIso, to: sevenDaysOut },
+  });
+}

--- a/src/app/api/v1/dashboard/this-weekend/route.ts
+++ b/src/app/api/v1/dashboard/this-weekend/route.ts
@@ -1,21 +1,25 @@
 // =============================================================================
 // GET /api/v1/dashboard/this-weekend
 // =============================================================================
-// "What can I hunt this weekend?" — surfaces OTC + open-season hunts near the
-// user's home state for the upcoming weekend (today + next 3 days). Used by
-// the dashboard activation widget.
+// "What can I hunt this weekend?" — surfaces OTC + open-season hunts for the
+// upcoming 7 days. When the user has a home state set, results are restricted
+// to that state's region (so a Georgia hunter doesn't see Alaska as a "this
+// weekend" suggestion). When no home state is set, fall back to the full
+// nationwide ranked list. Home-state matches always rank first via scoring
+// boost regardless of the region filter.
 //
 // Data sources (in order of preference):
 //   1. seasons table — for season_start <= today + 7d AND season_end >= today
 //   2. state_species table — to flag OTC vs draw
-//   3. user profile — to filter to user's home state + neighbors
+//   3. user profile — to learn home state (filter + scoring boost)
+//   4. states.region — to narrow to neighboring states ("south", "west", etc.)
 //
 // We deliberately return a small number (5) and keep the response light;
 // the widget is meant to be glanceable, not browsable.
 // =============================================================================
 
 import { NextResponse } from "next/server";
-import { and, eq, sql, gte, lte, or } from "drizzle-orm";
+import { and, eq, sql, gte, lte, or, inArray } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import {
@@ -72,6 +76,28 @@ export async function GET() {
     console.warn("[this-weekend] profile load failed (continuing):", err);
   }
 
+  // If we know the home state, restrict to that region (west/east/midwest/south).
+  // This addresses PR review feedback: the original implementation only used
+  // home state as a scoring boost, so the widget could surface nationwide
+  // results and label them as "this weekend" near-home suggestions. Without
+  // distance data we use the coarse `states.region` bucket as a sensible
+  // proxy — "near" doesn't have to mean adjacent, just plausibly drivable.
+  let allowedStateIds: string[] | null = null;
+  if (homeStateCode) {
+    const [home] = await db
+      .select({ region: states.region })
+      .from(states)
+      .where(eq(states.code, homeStateCode))
+      .limit(1);
+    if (home?.region) {
+      const sameRegion = await db
+        .select({ id: states.id })
+        .from(states)
+        .where(eq(states.region, home.region));
+      allowedStateIds = sameRegion.map((r) => r.id);
+    }
+  }
+
   // Pull active or imminent seasons.
   const rows = await db
     .select({
@@ -116,6 +142,11 @@ export async function GET() {
           // even when nonresidents can buy over-the-counter equivalents.
           sql`${seasons.tagType} IS NULL OR ${seasons.tagType} = 'draw'`,
         ),
+        // Home-state region filter: only narrow when we actually have a
+        // non-empty allow-list (defensive against weird region data).
+        allowedStateIds && allowedStateIds.length > 0
+          ? inArray(seasons.stateId, allowedStateIds)
+          : undefined,
       ),
     )
     .limit(60);

--- a/src/components/dashboard/ThisWeekendWidget.tsx
+++ b/src/components/dashboard/ThisWeekendWidget.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Sparkles, ChevronRight } from "lucide-react";
+
+interface WeekendOpportunity {
+  stateCode: string;
+  stateName: string;
+  speciesSlug: string;
+  speciesName: string;
+  seasonName: string | null;
+  weaponType: string | null;
+  tagType: "draw" | "otc" | "leftover" | "unknown";
+  seasonStart: string | null;
+  seasonEnd: string | null;
+  daysRemaining: number | null;
+  isHomeState: boolean;
+  isOtc: boolean;
+  publicLandPct: number | null;
+  rationale: string;
+}
+
+/**
+ * Dashboard activation widget: "What can I hunt this weekend?"
+ *
+ * Pulls OTC + open-season opportunities near the user's home state for the
+ * upcoming 7-day window. Designed to convert "I forgot HuntLogic exists"
+ * dormancy into a concrete action.
+ *
+ * The card silently renders nothing if the API returns no opportunities —
+ * preferable to a noisy empty state on the dashboard.
+ */
+export function ThisWeekendWidget() {
+  const [opportunities, setOpportunities] = useState<WeekendOpportunity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch("/api/v1/dashboard/this-weekend");
+        if (!res.ok) return;
+        const json = await res.json();
+        if (cancelled) return;
+        setOpportunities(json.opportunities ?? []);
+      } catch (err) {
+        console.error("[this-weekend] load failed:", err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-brand-sage/10 bg-white p-4 dark:border-brand-sage/20 dark:bg-brand-bark">
+        <div className="h-5 w-48 motion-safe:animate-pulse rounded-lg bg-brand-sage/10" />
+        <div className="mt-3 h-10 motion-safe:animate-pulse rounded-lg bg-brand-sage/10" />
+      </div>
+    );
+  }
+
+  if (opportunities.length === 0) {
+    // Silent: no opportunities = no widget. Dashboard already has plenty
+    // of widgets; don't add empty noise.
+    return null;
+  }
+
+  return (
+    <section className="rounded-xl border border-brand-sunset/20 bg-gradient-to-br from-brand-sunset/5 to-brand-sage/5 p-4 dark:border-brand-sunset/30 dark:from-brand-sunset/10 dark:to-brand-sage/10">
+      <header className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-brand-sunset" />
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-brand-sage">
+            What you can hunt this weekend
+          </h2>
+        </div>
+      </header>
+      <ul className="space-y-2">
+        {opportunities.map((opp) => {
+          const href = `/forecasts?state=${encodeURIComponent(opp.stateCode)}&species=${encodeURIComponent(opp.speciesSlug)}`;
+          return (
+            <li key={`${opp.stateCode}-${opp.speciesSlug}-${opp.seasonName ?? ""}`}>
+              <Link
+                href={href}
+                className="flex items-center justify-between gap-3 rounded-lg bg-white px-3 py-2.5 transition-colors hover:bg-brand-sage/5 dark:bg-brand-bark/40 dark:hover:bg-brand-sage/10"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-baseline gap-x-2">
+                    <p className="text-sm font-medium text-brand-bark dark:text-brand-cream">
+                      {opp.speciesName} — {opp.stateName}
+                    </p>
+                    {opp.isOtc && (
+                      <span className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-green-800 dark:bg-green-900/40 dark:text-green-300">
+                        OTC
+                      </span>
+                    )}
+                    {opp.isHomeState && (
+                      <span className="rounded bg-brand-forest/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-forest dark:bg-brand-sage/20 dark:text-brand-sage">
+                        Home
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-0.5 text-xs text-brand-sage">
+                    {opp.rationale}
+                    {opp.seasonName ? ` · ${opp.seasonName}` : ""}
+                  </p>
+                </div>
+                <ChevronRight className="h-4 w-4 shrink-0 text-brand-sage" />
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Activation widget for the dashboard. Converts dormant users into concrete plans by surfacing OTC + open-season opportunities near their home state for the next 7 days.

Why this matters: HuntLogic skews "long-horizon draw strategy." A weekend-actionable surface gives the same hunter a reason to open the app every week, not just every spring during draw application.

## What ships

**`GET /api/v1/dashboard/this-weekend`** — server-side scoring
- Pulls open seasons where `start ≤ today+7d AND end ≥ today`
- Joins `state_species` (left, since sparse) for OTC indicator
- Joins `hunt_units` for `public_land_pct`
- Scores: home_state +50, OTC +30, open_now +15, public_land_≥50% +10, long_window +5
- Top 5 by score, returns a `rationale` string for each card

**`<ThisWeekendWidget />`** on the dashboard
- Sage/sunset gradient card with `OTC` and `Home` chips
- Each row links to `/forecasts?state=...&species=...` for drill-down
- Silently hides when the API returns no opportunities (no noisy empty state)

## Test plan

- [ ] Sign in as a user with `home_state` preference set → widget surfaces home-state opportunities first
- [ ] User without `home_state` → widget still works using nation-wide signals
- [ ] Empty case (no seasons in window) → widget hides cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)