### PR TITLE
feat(chat): source citations on every concierge answer

### DIFF
--- a/src/app/api/v1/chat/route.ts
+++ b/src/app/api/v1/chat/route.ts
@@ -109,10 +109,30 @@ export async function POST(request: NextRequest) {
   const groundingContext = await buildGroundingContext(trimmedMessage);
 
   // Detect state + species so we can return clickable source links alongside
-  // the answer. The same detection function is called inside
-  // buildGroundingContext, but it's cheap enough to call again here and keeps
-  // the source-collection contract narrow + testable.
-  const detected = await detectStateAndSpecies(trimmedMessage);
+  // the answer. Review feedback (PR #18): detecting only against the current
+  // turn breaks follow-ups like "what about archery?" or "when's the
+  // deadline?" — the state/species context lives in the previous turn but
+  // gets dropped, so sources comes back empty. Fix: scan the current message
+  // first (most specific), then walk back through recent turns until we
+  // find a state OR species match. The current-turn match always wins when
+  // it exists, so explicit topic changes ("now tell me about Wyoming
+  // moose") still override stale context.
+  const recentUserTurns = sanitizedHistory
+    .filter((m) => m.role === "user")
+    .slice(-4)
+    .map((m) => m.content);
+  const detectionCandidates: string[] = [trimmedMessage, ...recentUserTurns.reverse()];
+  let detected: { stateId: string | null; speciesId: string | null } = {
+    stateId: null,
+    speciesId: null,
+  };
+  for (const candidate of detectionCandidates) {
+    const partial = await detectStateAndSpecies(candidate);
+    if (!detected.stateId && partial.stateId) detected.stateId = partial.stateId;
+    if (!detected.speciesId && partial.speciesId)
+      detected.speciesId = partial.speciesId;
+    if (detected.stateId && detected.speciesId) break;
+  }
   const sources = await collectSources({
     stateId: detected.stateId,
     speciesId: detected.speciesId,

--- a/src/app/api/v1/chat/route.ts
+++ b/src/app/api/v1/chat/route.ts
@@ -19,6 +19,7 @@ import {
   states,
   species,
   huntUnits,
+  stateRegulations,
 } from "@/lib/db/schema";
 import { config } from "@/lib/config";
 import { assembleContext } from "@/lib/ai/rag";
@@ -50,7 +51,8 @@ Behavior rules:
 - When the hunter asks for best zones, units, or application strategy, give a ranked or tiered answer with tradeoffs.
 - Separate official state-agency facts from hunter-consensus nuance. Label hunter-consensus guidance clearly.
 - Use specific numbers only when they are present in the grounded context. Never invent draw odds or tag counts.
-- If confidence is limited, say exactly what is uncertain.`;
+- If confidence is limited, say exactly what is uncertain.
+- When the message includes an "Authoritative sources" block, cite the most relevant entries inline using their bracket numbers (e.g. "[1]") immediately after the claim they support. Do NOT add a long "Sources" footer of your own — the UI renders the structured list separately. Only cite sources that were actually provided; do not invent citation numbers.`;
 
 let stateReferenceCache:
   | { id: string; code: string; name: string }[]
@@ -106,13 +108,33 @@ export async function POST(request: NextRequest) {
 
   const groundingContext = await buildGroundingContext(trimmedMessage);
 
-  // Assemble full message: profile context + grounding + conversation history + current message
+  // Detect state + species so we can return clickable source links alongside
+  // the answer. The same detection function is called inside
+  // buildGroundingContext, but it's cheap enough to call again here and keeps
+  // the source-collection contract narrow + testable.
+  const detected = await detectStateAndSpecies(trimmedMessage);
+  const sources = await collectSources({
+    stateId: detected.stateId,
+    speciesId: detected.speciesId,
+  });
+
+  // Assemble full message: profile context + grounding + sources + history + question.
+  // Sources are inlined as well so the model can cite them in-line; the
+  // structured `sources` array travels back in the response for the UI.
   const messageParts: string[] = [];
   if (profileContext) {
     messageParts.push(profileContext);
   }
   if (groundingContext) {
     messageParts.push(groundingContext);
+  }
+  if (sources.length > 0) {
+    const sourcesBlock = sources
+      .map((s, i) => `[${i + 1}] ${s.name}${s.url ? ` — ${s.url}` : ""}`)
+      .join("\n");
+    messageParts.push(
+      `Authoritative sources (cite by [n] when you use them in the answer):\n${sourcesBlock}`,
+    );
   }
   if (contextLines) {
     messageParts.push(`Previous conversation:\n${contextLines}`);
@@ -124,7 +146,7 @@ export async function POST(request: NextRequest) {
   // Try OpenClaw gateway first, then fall back to Anthropic, Gemini, and OpenAI
   try {
     const reply = await callOpenClawGateway(fullMessage);
-    return NextResponse.json({ text: reply });
+    return NextResponse.json({ text: reply, sources });
   } catch (gatewayErr) {
     console.warn(
       "[chat] OpenClaw gateway unavailable, trying direct providers:",
@@ -133,7 +155,7 @@ export async function POST(request: NextRequest) {
 
     try {
       const reply = await callAnthropicDirect(fullMessage);
-      return NextResponse.json({ text: reply });
+      return NextResponse.json({ text: reply, sources });
     } catch (anthropicErr) {
       console.warn(
         "[chat] Anthropic unavailable, trying Gemini:",
@@ -142,7 +164,7 @@ export async function POST(request: NextRequest) {
 
       try {
         const reply = await callGeminiDirect(fullMessage);
-        return NextResponse.json({ text: reply });
+        return NextResponse.json({ text: reply, sources });
       } catch (geminiErr) {
         console.warn(
           "[chat] Gemini unavailable, trying OpenAI:",
@@ -151,7 +173,7 @@ export async function POST(request: NextRequest) {
 
         try {
           const reply = await callOpenAIDirect(fullMessage);
-          return NextResponse.json({ text: reply });
+          return NextResponse.json({ text: reply, sources });
         } catch (openaiErr) {
           console.error("[chat] All backends failed:", openaiErr);
           return NextResponse.json(
@@ -162,6 +184,94 @@ export async function POST(request: NextRequest) {
       }
     }
   }
+}
+
+// =============================================================================
+// Source collection — collects citation candidates from authoritative tables
+// (state agency URL, state regulation docs, regulation snapshots) keyed off
+// the state/species detected in the user's message.
+// =============================================================================
+
+interface ChatSource {
+  /** Short human-readable label, e.g. "Colorado Parks & Wildlife" */
+  name: string;
+  /** Canonical URL — null for sources we know the name of but not a URL */
+  url: string | null;
+  /** Where it came from: lets the UI render different chip styles */
+  kind: "agency" | "regulation_doc" | "snapshot";
+}
+
+async function collectSources(opts: {
+  stateId: string | null;
+  speciesId: string | null;
+}): Promise<ChatSource[]> {
+  if (!opts.stateId) return [];
+
+  const results: ChatSource[] = [];
+
+  // 1) State agency homepage from `states.agencyName` + `states.agencyUrl`.
+  try {
+    const [state] = await db
+      .select({
+        name: states.name,
+        agencyName: states.agencyName,
+        agencyUrl: states.agencyUrl,
+      })
+      .from(states)
+      .where(eq(states.id, opts.stateId))
+      .limit(1);
+    if (state && state.agencyUrl) {
+      results.push({
+        name: state.agencyName ?? `${state.name} Wildlife Agency`,
+        url: state.agencyUrl,
+        kind: "agency",
+      });
+    }
+  } catch (err) {
+    console.warn("[chat:sources] agency lookup failed:", err);
+  }
+
+  // 2) Up to two regulation docs (hunt planner / big game regs) for this state.
+  try {
+    const docs = await db
+      .select({
+        title: stateRegulations.title,
+        url: stateRegulations.url,
+      })
+      .from(stateRegulations)
+      .where(
+        and(
+          eq(stateRegulations.stateId, opts.stateId),
+          eq(stateRegulations.enabled, true),
+        ),
+      )
+      .limit(3);
+    for (const doc of docs) {
+      if (!doc.url) continue;
+      results.push({
+        name: doc.title,
+        url: doc.url,
+        kind: "regulation_doc",
+      });
+    }
+  } catch (err) {
+    console.warn("[chat:sources] regulation lookup failed:", err);
+  }
+
+  // 3) (Future) Once feat/data-layer-overhaul merges, also pull the active
+  // regulation snapshot for the current year — that's the canonical
+  // version-pinned regulation text and the strongest provenance signal.
+  // Tracked separately to keep this PR independent of the schema migration.
+
+  // De-duplicate by url; preserve insertion order so agency/regulation/snapshot
+  // order is preserved.
+  const seen = new Set<string>();
+  return results.filter((s) => {
+    const key = (s.url ?? s.name).toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 // =============================================================================

--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { ChatMessage } from "./ChatMessage";
+import { ChatMessage, type ChatSource } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 
 interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
+  sources?: ChatSource[];
 }
 
 interface ChatResponse {
   text?: string;
+  sources?: ChatSource[];
 }
 
 const aiName = process.env.NEXT_PUBLIC_AI_ASSISTANT_NAME || "Grizz";
@@ -78,7 +80,8 @@ export function ChatContainer() {
           );
         }
 
-        // Update assistant message with Grizz's response
+        // Update assistant message with Grizz's response and attach any
+        // source citations the backend collected.
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId
@@ -88,6 +91,8 @@ export function ChatContainer() {
                     data && "text" in data && data.text
                       ? data.text
                       : "Sorry, I didn't get a response.",
+                  sources:
+                    data && "sources" in data ? data.sources : undefined,
                 }
               : m,
           ),
@@ -157,6 +162,7 @@ export function ChatContainer() {
               msg.id === messages[messages.length - 1]?.id &&
               msg.role === "assistant"
             }
+            sources={msg.sources}
           />
         ))}
         <div ref={bottomRef} />

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -2,18 +2,27 @@
 
 import { memo, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { User } from "lucide-react";
+import { User, ExternalLink } from "lucide-react";
+
+export interface ChatSource {
+  name: string;
+  url: string | null;
+  kind?: "agency" | "regulation_doc" | "snapshot";
+}
 
 interface ChatMessageProps {
   role: "user" | "assistant";
   content: string;
   isStreaming?: boolean;
+  /** Source citations to render below the assistant's reply, if any. */
+  sources?: ChatSource[];
 }
 
 export const ChatMessage = memo(function ChatMessage({
   role,
   content,
   isStreaming,
+  sources,
 }: ChatMessageProps) {
   const isUser = role === "user";
 
@@ -54,12 +63,65 @@ export const ChatMessage = memo(function ChatMessage({
         ) : (
           <div className="space-y-3">
             {renderAssistantContent(content, isStreaming)}
+            {/* Inline citations — agency URLs + regulation snapshots that
+               were attached to the response payload. Only render after
+               streaming so the chips don't flicker in mid-stream. */}
+            {!isStreaming && sources && sources.length > 0 && (
+              <SourcesRow sources={sources} />
+            )}
           </div>
         )}
       </div>
     </div>
   );
 });
+
+function SourcesRow({ sources }: { sources: ChatSource[] }) {
+  return (
+    <div className="border-t border-brand-sage/15 pt-2 dark:border-brand-sage/25">
+      <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-brand-sage">
+        Sources
+      </p>
+      <ul className="flex flex-wrap gap-1.5">
+        {sources.map((src, i) => {
+          const inner = (
+            <span className="flex items-center gap-1 text-[11px]">
+              <span className="rounded-sm bg-brand-sage/10 px-1 py-0.5 font-mono text-[9px] text-brand-sage">
+                [{i + 1}]
+              </span>
+              <span className="line-clamp-1 max-w-[180px]">{src.name}</span>
+              {src.url && (
+                <ExternalLink className="h-2.5 w-2.5 text-brand-sage" />
+              )}
+            </span>
+          );
+          if (src.url) {
+            return (
+              <li key={`${src.name}-${i}`}>
+                <a
+                  href={src.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center rounded-md border border-brand-sage/20 bg-white/60 px-2 py-0.5 transition-colors hover:border-brand-forest/30 hover:bg-brand-forest/5 dark:bg-brand-bark/40 dark:hover:bg-brand-forest/10"
+                >
+                  {inner}
+                </a>
+              </li>
+            );
+          }
+          return (
+            <li
+              key={`${src.name}-${i}`}
+              className="inline-flex items-center rounded-md border border-brand-sage/15 bg-brand-sage/5 px-2 py-0.5 text-brand-sage"
+            >
+              {inner}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
 
 function renderAssistantContent(
   content: string,


### PR DESCRIPTION
## Summary

Hunters got confident answers from Grizz with **no provenance**. New hunters especially had no way to verify whether a rule actually came from the state regs or the model hallucinating. This PR closes the trust gap.

## What ships

**Backend (`/api/v1/chat`)**
- Detects state + species from the message (existing helper)
- Collects authoritative sources from `states.agencyUrl` and `state_regulations`
- Inlines them into the LLM context as a numbered list with cite-by-[n] instructions
- Returns a structured `sources: ChatSource[]` array alongside `text`

**System prompt**
- New rule: cite the most relevant entries inline using their bracket numbers ([1], [2]) immediately after the supported claim. Never invent citation numbers. Don't add a long footer of your own — the UI renders the structured list.

**UI**
- `ChatMessage` gains an optional `sources` prop. Renders a compact Sources chip row below the streamed message, with external-link icons on URLs
- `ChatContainer` threads `sources` from the response through to each message

## Follow-up

Once `feat/data-layer-overhaul` (#11) lands, also pull the active `regulation_snapshots` row for the year — the version-pinned canonical text. Comment-in-code marks the hook.

## Test plan

- [ ] Send chat: "What are draw odds for Colorado elk unit 12?" → response includes Sources chips for CPW agency + any seeded regulation docs
- [ ] Verify model uses [1], [2] inline citations in its reply
- [ ] Click an external-link chip → opens in new tab
- [ ] Send chat with no state/species → no Sources row rendered (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)