### PR TITLE
feat(notifications): browser push activation (VAPID)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-toast": "^1.2.5",
         "@tanstack/react-query": "^5.65.0",
         "@types/bcryptjs": "^2.4.6",
+        "@types/web-push": "^3.6.4",
         "ai": "^4.1.0",
         "bcryptjs": "^3.0.3",
         "bullmq": "^5.34.0",
@@ -45,6 +46,7 @@
         "sharp": "^0.33.0",
         "stripe": "^20.4.1",
         "tailwind-merge": "^3.0.0",
+        "web-push": "^3.6.7",
         "xlsx": "^0.18.5",
         "zod": "^3.24.0",
         "zustand": "^5.0.0"
@@ -4324,6 +4326,15 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
@@ -5323,6 +5334,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5459,6 +5482,12 @@
       "dependencies": {
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -8232,6 +8261,15 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -9590,6 +9628,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -10879,6 +10923,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14039,6 +14084,25 @@
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-toast": "^1.2.5",
     "@tanstack/react-query": "^5.65.0",
     "@types/bcryptjs": "^2.4.6",
+    "@types/web-push": "^3.6.4",
     "ai": "^4.1.0",
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.34.0",
@@ -60,6 +61,7 @@
     "sharp": "^0.33.0",
     "stripe": "^20.4.1",
     "tailwind-merge": "^3.0.0",
+    "web-push": "^3.6.7",
     "xlsx": "^0.18.5",
     "zod": "^3.24.0",
     "zustand": "^5.0.0"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,13 +1,76 @@
-// Service worker disabled — nuke all caches and unregister
-self.addEventListener("install", () => self.skipWaiting());
+// =============================================================================
+// HuntLogic service worker — web push delivery
+// =============================================================================
+// Lifecycle:
+//   - install: skipWaiting so updates propagate without a refresh.
+//   - activate: claim all clients (no cache strategy; this SW is intentionally
+//     cache-less to avoid the stale-bundle issues that prompted the previous
+//     "nuke all caches" SW). On first activation we also clear any caches
+//     left behind by older worker versions.
+//   - push: render a notification from the JSON payload our server sends.
+//   - notificationclick: focus an existing tab or open one to the deep link.
+// =============================================================================
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys()
+    caches
+      .keys()
       .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
-      .then(() => self.clients.claim())
-      .then(() => self.clients.matchAll())
-      .then((clients) => {
-        clients.forEach((client) => client.navigate(client.url));
-      })
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: "HuntLogic", body: event.data.text() };
+  }
+
+  const title = payload.title || "HuntLogic";
+  const options = {
+    body: payload.body || "",
+    icon: payload.icon || "/icon-192.png",
+    badge: payload.badge || "/icon-192.png",
+    tag: payload.tag,
+    data: {
+      url: payload.url || "/dashboard",
+      ...(payload.data || {}),
+    },
+    requireInteraction: false,
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const targetUrl = event.notification.data?.url || "/dashboard";
+
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+      // If a HuntLogic tab is already open, focus it and navigate.
+      for (const client of clients) {
+        if (client.url.includes(self.registration.scope) && "focus" in client) {
+          client.focus();
+          if ("navigate" in client) {
+            return client.navigate(targetUrl);
+          }
+          return undefined;
+        }
+      }
+      // Otherwise, open a new tab.
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl);
+      }
+      return undefined;
+    }),
   );
 });

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import { Bell, Globe, User, Shield, Download, Check, Link2, ChevronRight, Trash2
 import { apiClient } from "@/lib/api/client";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { PushNotificationToggle } from "@/components/settings/PushNotificationToggle";
 
 interface NotifPrefs {
   emailEnabled: boolean;
@@ -171,6 +172,13 @@ export default function SettingsPage() {
           <ToggleRow label="Draw Results" description="Notifications when draw results are posted" checked={notifPrefs.drawResults} onChange={(v) => updateNotif("drawResults", v)} />
           <ToggleRow label="Strategy Updates" description="When your recommendations change" checked={notifPrefs.strategyUpdates} onChange={(v) => updateNotif("strategyUpdates", v)} />
           <ToggleRow label="Point Creep Alerts" description="When point requirements shift significantly" checked={notifPrefs.pointCreepAlerts} onChange={(v) => updateNotif("pointCreepAlerts", v)} />
+          {/* Browser push opt-in — per-device, independent of the email + in-app channels above */}
+          <div className="border-t border-brand-sage/10 pt-3 dark:border-brand-sage/20">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-brand-sage">
+              Browser push (this device)
+            </p>
+            <PushNotificationToggle />
+          </div>
         </div>
       </SettingsCard>
 

--- a/src/app/api/v1/notifications/push/subscribe/route.ts
+++ b/src/app/api/v1/notifications/push/subscribe/route.ts
@@ -1,0 +1,130 @@
+// =============================================================================
+// POST /api/v1/notifications/push/subscribe
+// DELETE /api/v1/notifications/push/subscribe
+// GET    /api/v1/notifications/push/subscribe — returns the public VAPID key
+// =============================================================================
+// Manages the user's browser PushSubscription. The browser hands us an
+// endpoint + p256dh + auth tuple after `pushManager.subscribe()`; we store
+// it so the deadline cron can deliver pushes to it later.
+// =============================================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { pushSubscriptions } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+
+export async function GET() {
+  // Expose the public VAPID key so the client can call
+  // pushManager.subscribe({ applicationServerKey, userVisibleOnly: true }).
+  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? process.env.VAPID_PUBLIC_KEY ?? null;
+  if (!publicKey) {
+    return NextResponse.json(
+      { error: "Push not configured", configured: false },
+      { status: 503 },
+    );
+  }
+  return NextResponse.json({ publicKey, configured: true });
+}
+
+interface SubscribeBody {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+  userAgent?: string;
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: SubscribeBody;
+  try {
+    body = (await request.json()) as SubscribeBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (
+    !body?.endpoint ||
+    !body.keys?.p256dh ||
+    !body.keys?.auth ||
+    typeof body.endpoint !== "string"
+  ) {
+    return NextResponse.json(
+      { error: "endpoint, keys.p256dh, and keys.auth are required" },
+      { status: 400 },
+    );
+  }
+
+  // Endpoints are globally unique. If this endpoint already exists, update
+  // it (re-bind to current user, refresh keys, mark active).
+  const existing = await db
+    .select()
+    .from(pushSubscriptions)
+    .where(eq(pushSubscriptions.endpoint, body.endpoint))
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .update(pushSubscriptions)
+      .set({
+        userId: session.user.id,
+        p256dh: body.keys.p256dh,
+        auth: body.keys.auth,
+        userAgent: body.userAgent ?? null,
+        active: true,
+        subscribedAt: new Date(),
+      })
+      .where(eq(pushSubscriptions.id, existing[0]!.id));
+    return NextResponse.json({ updated: true });
+  }
+
+  await db.insert(pushSubscriptions).values({
+    userId: session.user.id,
+    endpoint: body.endpoint,
+    p256dh: body.keys.p256dh,
+    auth: body.keys.auth,
+    userAgent: body.userAgent ?? null,
+  });
+  return NextResponse.json({ created: true });
+}
+
+interface UnsubscribeBody {
+  endpoint?: string;
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: UnsubscribeBody = {};
+  try {
+    body = (await request.json()) as UnsubscribeBody;
+  } catch {
+    // Body is optional — without an endpoint we unsubscribe all of the
+    // user's subscriptions (e.g. "turn off browser push everywhere").
+  }
+
+  if (body.endpoint) {
+    await db
+      .update(pushSubscriptions)
+      .set({ active: false })
+      .where(
+        and(
+          eq(pushSubscriptions.userId, session.user.id),
+          eq(pushSubscriptions.endpoint, body.endpoint),
+        ),
+      );
+  } else {
+    await db
+      .update(pushSubscriptions)
+      .set({ active: false })
+      .where(eq(pushSubscriptions.userId, session.user.id));
+  }
+
+  return NextResponse.json({ deactivated: true });
+}

--- a/src/components/settings/PushNotificationToggle.tsx
+++ b/src/components/settings/PushNotificationToggle.tsx
@@ -120,15 +120,45 @@ export function PushNotificationToggle() {
       });
 
       const json = sub.toJSON();
-      await fetch("/api/v1/notifications/push/subscribe", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          endpoint: json.endpoint,
-          keys: json.keys,
-          userAgent: navigator.userAgent,
-        }),
-      });
+      // Persist the subscription server-side. The browser-side subscription
+      // already exists at this point — if the server rejects (auth, validation,
+      // VAPID misconfig), we MUST unwind the browser subscription too,
+      // otherwise the browser holds a push subscription the server never
+      // stored and the user sees "subscribed" while push delivery is dead.
+      let serverPersisted = false;
+      try {
+        const res = await fetch("/api/v1/notifications/push/subscribe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            endpoint: json.endpoint,
+            keys: json.keys,
+            userAgent: navigator.userAgent,
+          }),
+        });
+        serverPersisted = res.ok;
+        if (!res.ok) {
+          console.warn(
+            "[push:toggle] server rejected subscription:",
+            res.status,
+            await res.text().catch(() => ""),
+          );
+        }
+      } catch (err) {
+        console.error("[push:toggle] server POST failed:", err);
+      }
+
+      if (!serverPersisted) {
+        // Unwind the browser subscription so state matches reality.
+        try {
+          await sub.unsubscribe();
+        } catch (err) {
+          console.warn("[push:toggle] unwind unsubscribe failed:", err);
+        }
+        setStatus("unsubscribed");
+        return;
+      }
+
       setStatus("subscribed");
     } catch (err) {
       console.error("[push:toggle] subscribe failed:", err);

--- a/src/components/settings/PushNotificationToggle.tsx
+++ b/src/components/settings/PushNotificationToggle.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bell, BellOff, Check, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Status =
+  | "unknown"
+  | "unsupported"
+  | "not-configured"
+  | "denied"
+  | "subscribed"
+  | "unsubscribed";
+
+/**
+ * Opt-in control for browser push notifications.
+ *
+ * Lifecycle:
+ *   1. Detect browser capability (PushManager, Notification, ServiceWorker)
+ *   2. Fetch the server's VAPID public key
+ *   3. Read the current SW registration's existing subscription, if any
+ *   4. On user click → request Notification permission → subscribe via
+ *      pushManager.subscribe → POST the subscription to our API.
+ *
+ * This is intentionally a UI-only opt-in surface. The actual notification
+ * preferences (deadlineReminders / drawResults / etc.) live elsewhere on
+ * Settings and gate which events fire pushes server-side.
+ */
+
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const b64 = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(b64);
+  const buf = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) buf[i] = raw.charCodeAt(i);
+  return buf;
+}
+
+export function PushNotificationToggle() {
+  const [status, setStatus] = useState<Status>("unknown");
+  const [busy, setBusy] = useState(false);
+  const [vapidKey, setVapidKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      if (
+        typeof window === "undefined" ||
+        !("serviceWorker" in navigator) ||
+        !("PushManager" in window) ||
+        !("Notification" in window)
+      ) {
+        if (!cancelled) setStatus("unsupported");
+        return;
+      }
+
+      // Fetch VAPID public key from server
+      try {
+        const res = await fetch("/api/v1/notifications/push/subscribe");
+        if (!res.ok) {
+          if (!cancelled) setStatus("not-configured");
+          return;
+        }
+        const json = await res.json();
+        if (!json.configured || !json.publicKey) {
+          if (!cancelled) setStatus("not-configured");
+          return;
+        }
+        if (!cancelled) setVapidKey(json.publicKey);
+      } catch {
+        if (!cancelled) setStatus("not-configured");
+        return;
+      }
+
+      // Check current state
+      if (Notification.permission === "denied") {
+        if (!cancelled) setStatus("denied");
+        return;
+      }
+
+      try {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        if (!cancelled) setStatus(sub ? "subscribed" : "unsubscribed");
+      } catch (err) {
+        console.warn("[push:toggle] SW ready failed:", err);
+        if (!cancelled) setStatus("unsubscribed");
+      }
+    }
+
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const subscribe = async () => {
+    if (!vapidKey || busy) return;
+    setBusy(true);
+    try {
+      // Make sure the SW is registered
+      const reg = await navigator.serviceWorker.register("/sw.js");
+      await navigator.serviceWorker.ready;
+
+      // Request permission
+      const perm = await Notification.requestPermission();
+      if (perm !== "granted") {
+        setStatus(perm === "denied" ? "denied" : "unsubscribed");
+        return;
+      }
+
+      // TS/lib types for PushSubscriptionOptionsInit are strict about the
+      // ArrayBufferLike narrowing; the Uint8Array we produce is correct at
+      // runtime, just not provably non-SharedArrayBuffer-backed.
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey:
+          urlBase64ToUint8Array(vapidKey) as unknown as BufferSource,
+      });
+
+      const json = sub.toJSON();
+      await fetch("/api/v1/notifications/push/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          endpoint: json.endpoint,
+          keys: json.keys,
+          userAgent: navigator.userAgent,
+        }),
+      });
+      setStatus("subscribed");
+    } catch (err) {
+      console.error("[push:toggle] subscribe failed:", err);
+      setStatus("unsubscribed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const unsubscribe = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        const endpoint = sub.endpoint;
+        await sub.unsubscribe();
+        await fetch("/api/v1/notifications/push/subscribe", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ endpoint }),
+        });
+      }
+      setStatus("unsubscribed");
+    } catch (err) {
+      console.error("[push:toggle] unsubscribe failed:", err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ----- Render branches -----
+
+  if (status === "unknown") {
+    return (
+      <div className="h-10 w-full motion-safe:animate-pulse rounded-lg bg-brand-sage/10" />
+    );
+  }
+
+  if (status === "unsupported") {
+    return (
+      <p className="text-xs italic text-brand-sage">
+        Browser push not supported on this device or browser.
+      </p>
+    );
+  }
+
+  if (status === "not-configured") {
+    return (
+      <p className="text-xs italic text-brand-sage">
+        Browser push not configured on the server yet (admin: set
+        VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY).
+      </p>
+    );
+  }
+
+  if (status === "denied") {
+    return (
+      <div className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        Notifications are blocked for this site. Re-enable them in your
+        browser&apos;s site settings, then refresh.
+      </div>
+    );
+  }
+
+  if (status === "subscribed") {
+    return (
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm text-brand-bark dark:text-brand-cream">
+          <Check className="h-4 w-4 text-brand-forest" />
+          Browser push is on for this device.
+        </div>
+        <button
+          type="button"
+          onClick={unsubscribe}
+          disabled={busy}
+          className={cn(
+            "flex items-center gap-1.5 rounded-md border border-brand-sage/30 px-3 py-1.5 text-xs font-medium text-brand-sage transition-colors hover:bg-brand-sage/10",
+            busy && "opacity-50",
+          )}
+        >
+          <BellOff className="h-3.5 w-3.5" />
+          Turn off
+        </button>
+      </div>
+    );
+  }
+
+  // unsubscribed
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="text-sm text-brand-bark dark:text-brand-cream">
+        Get deadline + draw-result reminders on this device.
+      </div>
+      <button
+        type="button"
+        onClick={subscribe}
+        disabled={busy}
+        className={cn(
+          "flex items-center gap-1.5 rounded-md bg-brand-forest px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-forest/90",
+          busy && "opacity-50",
+        )}
+      >
+        {busy ? (
+          <X className="h-3.5 w-3.5 motion-safe:animate-pulse" />
+        ) : (
+          <Bell className="h-3.5 w-3.5" />
+        )}
+        Enable
+      </button>
+    </div>
+  );
+}

--- a/src/lib/db/migrations/0102_push_subscriptions.sql
+++ b/src/lib/db/migrations/0102_push_subscriptions.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- Migration 0102 — Web Push Subscriptions
+-- =============================================================================
+-- Holds the VAPID-keyed PushSubscription objects browsers hand us when a
+-- user opts into notifications. One row per (user, browser endpoint).
+--
+-- Additive — no destructive ops. Safe to re-run.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  -- The browser's push service endpoint URL.
+  endpoint TEXT NOT NULL,
+  -- VAPID auth + p256dh keys from the subscription.
+  p256dh TEXT NOT NULL,
+  auth TEXT NOT NULL,
+  -- Optional metadata to help ops understand who's subscribed (UA, OS, etc).
+  user_agent TEXT,
+  -- When the user last opted in / re-subscribed (browser endpoints can churn).
+  subscribed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- When we last successfully sent a push to this subscription (used to
+  -- prune dead subscriptions on 410 Gone from the push service).
+  last_used_at TIMESTAMPTZ,
+  -- Subscriptions can be marked inactive without deletion so we keep audit.
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS push_subscriptions_endpoint_idx
+  ON push_subscriptions(endpoint);
+CREATE INDEX IF NOT EXISTS push_subscriptions_user_id_idx
+  ON push_subscriptions(user_id);
+CREATE INDEX IF NOT EXISTS push_subscriptions_active_idx
+  ON push_subscriptions(active);

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -62,6 +62,12 @@ export {
   notificationPreferencesRelations,
 } from "./notifications";
 
+// Push subscriptions (VAPID web push)
+export {
+  pushSubscriptions,
+  pushSubscriptionsRelations,
+} from "./push-subscriptions";
+
 // Data sources domain
 export {
   dataSources,

--- a/src/lib/db/schema/push-subscriptions.ts
+++ b/src/lib/db/schema/push-subscriptions.ts
@@ -1,0 +1,54 @@
+import { relations } from "drizzle-orm";
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  boolean,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+// ========================
+// PUSH SUBSCRIPTIONS — VAPID-keyed browser PushSubscription objects.
+// One row per (user, browser endpoint). Endpoints are unique globally
+// (different browser/device = different endpoint).
+// ========================
+
+export const pushSubscriptions = pgTable(
+  "push_subscriptions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    endpoint: text("endpoint").notNull(),
+    p256dh: text("p256dh").notNull(),
+    auth: text("auth").notNull(),
+    userAgent: text("user_agent"),
+    subscribedAt: timestamp("subscribed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    active: boolean("active").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("push_subscriptions_endpoint_idx").on(table.endpoint),
+    index("push_subscriptions_user_id_idx").on(table.userId),
+    index("push_subscriptions_active_idx").on(table.active),
+  ],
+);
+
+export const pushSubscriptionsRelations = relations(
+  pushSubscriptions,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [pushSubscriptions.userId],
+      references: [users.id],
+    }),
+  }),
+);

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -101,6 +101,26 @@ export async function createNotification(
       console.warn("[notifications] Email send failed:", err);
     });
   }
+
+  // Browser push (non-blocking). Gated by pushEnabled pref + having an
+  // active subscription. The web-push service no-ops silently when VAPID
+  // env vars aren't set, so this is safe to call unconditionally.
+  if (!prefs || prefs.pushEnabled) {
+    (async () => {
+      try {
+        const { sendPushToUser } = await import("./web-push");
+        await sendPushToUser(input.userId, {
+          title: input.title,
+          body: input.body,
+          url: input.actionUrl,
+          tag: input.type,
+          data: { ...(input.metadata ?? {}), type: input.type },
+        });
+      } catch (err) {
+        console.warn("[notifications] Push send failed:", err);
+      }
+    })();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/notifications/web-push.ts
+++ b/src/services/notifications/web-push.ts
@@ -1,0 +1,123 @@
+// =============================================================================
+// Web Push delivery — VAPID-signed push notifications to subscribed browsers
+// =============================================================================
+// Wraps the `web-push` library. Reads VAPID keys from env (set them once
+// per environment via `npx web-push generate-vapid-keys`). Stale subscriptions
+// (HTTP 404 / 410 from the push service) are pruned automatically.
+// =============================================================================
+
+import webpush from "web-push";
+import { db } from "@/lib/db";
+import { pushSubscriptions } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+
+const LOG_PREFIX = "[push]";
+
+let vapidConfigured = false;
+
+function ensureVapidConfigured(): boolean {
+  if (vapidConfigured) return true;
+  const publicKey = process.env.VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+  const subject = process.env.VAPID_SUBJECT ?? "mailto:support@huntlogic.com";
+  if (!publicKey || !privateKey) {
+    console.warn(
+      `${LOG_PREFIX} VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY missing — push delivery is a no-op until set.`,
+    );
+    return false;
+  }
+  webpush.setVapidDetails(subject, publicKey, privateKey);
+  vapidConfigured = true;
+  return true;
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  url?: string;
+  icon?: string;
+  tag?: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Send a push notification to every active subscription belonging to `userId`.
+ *
+ * Returns the count of successful sends. Stale subscriptions (gone from the
+ * push service) are marked inactive so subsequent sends skip them.
+ */
+export async function sendPushToUser(
+  userId: string,
+  payload: PushPayload,
+): Promise<number> {
+  if (!ensureVapidConfigured()) return 0;
+
+  const subs = await db
+    .select()
+    .from(pushSubscriptions)
+    .where(
+      and(
+        eq(pushSubscriptions.userId, userId),
+        eq(pushSubscriptions.active, true),
+      ),
+    );
+
+  if (subs.length === 0) return 0;
+
+  const body = JSON.stringify({
+    title: payload.title,
+    body: payload.body,
+    url: payload.url ?? "/dashboard",
+    icon: payload.icon ?? "/icon-192.png",
+    tag: payload.tag,
+    data: payload.data ?? {},
+  });
+
+  let successCount = 0;
+
+  await Promise.all(
+    subs.map(async (sub) => {
+      try {
+        await webpush.sendNotification(
+          {
+            endpoint: sub.endpoint,
+            keys: { p256dh: sub.p256dh, auth: sub.auth },
+          },
+          body,
+          {
+            TTL: 60 * 60 * 24, // 24h relevance window
+            urgency: "normal",
+          },
+        );
+        successCount++;
+        // Best-effort: update lastUsedAt; ignore failures.
+        await db
+          .update(pushSubscriptions)
+          .set({ lastUsedAt: new Date() })
+          .where(eq(pushSubscriptions.id, sub.id))
+          .catch(() => {});
+      } catch (err: unknown) {
+        const status =
+          err && typeof err === "object" && "statusCode" in err
+            ? (err as { statusCode?: number }).statusCode
+            : undefined;
+        // 404 / 410 = subscription is gone from the push service. Mark
+        // inactive so we don't keep trying. Anything else, just log.
+        if (status === 404 || status === 410) {
+          console.log(
+            `${LOG_PREFIX} pruning stale subscription ${sub.id} (status ${status})`,
+          );
+          await db
+            .update(pushSubscriptions)
+            .set({ active: false })
+            .where(eq(pushSubscriptions.id, sub.id))
+            .catch(() => {});
+        } else {
+          console.warn(`${LOG_PREFIX} send failed:`, err);
+        }
+      }
+    }),
+  );
+
+  return successCount;
+}


### PR DESCRIPTION
## Summary

The notification system had 3 of 4 channels working: in-app feed (TopBar bell), email via Resend, and a daily deadline-reminder cron. **Browser push was the missing piece** — the schema had VAPID env keys but no subscription infrastructure. This PR ships it.

## What ships

**Schema** (migration 0102, additive):
- `push_subscriptions` table: per-device subscription with VAPID keys, last-used tracking, active flag

**Server**:
- `services/notifications/web-push.ts` — wraps `web-push` library; fans out to every active subscription; prunes stale endpoints (HTTP 404/410); silently no-ops when VAPID env vars aren't set
- Existing `createNotification()` now also fires browser push alongside the in-app row + email (gated by `notificationPreferences.pushEnabled`)
- `/api/v1/notifications/push/subscribe`: POST (upsert), DELETE (deactivate), GET (expose public VAPID key)

**Client**:
- `public/sw.js` — real service worker with `push` + `notificationclick` handlers. Opens an existing HuntLogic tab and deep-links to the `actionUrl`. Replaces the previous "nuke all caches" placeholder
- `<PushNotificationToggle />` — Settings opt-in. Detects browser capability, fetches VAPID key, registers SW, requests Notification permission, subscribes, POSTs to API. Handles denied / not-configured / unsubscribed states
- Wired into Settings → Notifications card under "Browser push (this device)"

## Env vars needed in Vercel

```
VAPID_PUBLIC_KEY=...           # also surfaced as NEXT_PUBLIC_VAPID_PUBLIC_KEY
VAPID_PRIVATE_KEY=...
VAPID_SUBJECT=mailto:support@huntlogic.com
```

Generate with `npx web-push generate-vapid-keys`.

## Apply order for prod

```bash
psql $DATABASE_URL -f src/lib/db/migrations/0102_push_subscriptions.sql
# Set VAPID_* env in Vercel
# Deploy
```

## Test plan

- [ ] Visit Settings → see "Browser push" row. Click Enable → permission prompt → push subscribes
- [ ] Trigger any notification (e.g. wait for the daily deadline cron or hit a transactional endpoint) → browser notification appears
- [ ] Click the notification → focuses an open HuntLogic tab, navigates to the deep link
- [ ] Click "Turn off" → subscription deactivated
- [ ] Without VAPID env vars set → UI shows "not configured" instead of breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)