### PR TITLE
feat(groups): joint application strategy view

### DIFF
--- a/src/app/(dashboard)/groups/[id]/page.tsx
+++ b/src/app/(dashboard)/groups/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   ArrowLeft,
 } from "lucide-react";
 import Link from "next/link";
+import { GroupStrategyView } from "@/components/groups/GroupStrategyView";
 
 interface GroupMember {
   id: string;
@@ -213,6 +214,10 @@ export default function GroupDetailPage() {
           </div>
         )}
       </div>
+
+      {/* Joint application strategy — pulls each active member's playbook,
+         aggregates coverage, flags duplicates, suggests splits. */}
+      <GroupStrategyView groupId={group.id} />
 
       {/* Plans */}
       <div className="rounded-xl border border-brand-sage/10 bg-white p-5 shadow-sm dark:border-brand-sage/20 dark:bg-brand-bark">

--- a/src/app/api/v1/groups/[id]/strategy/route.ts
+++ b/src/app/api/v1/groups/[id]/strategy/route.ts
@@ -1,0 +1,282 @@
+// =============================================================================
+// GET /api/v1/groups/[id]/strategy
+// =============================================================================
+// "Joint application strategy" view for a hunt group.
+//
+// For each active group member with an active playbook, pull their top
+// recommendations and aggregate them into:
+//   1. coverage    — distinct (state, species) the group collectively targets
+//   2. overlap     — hunts where 2+ members are applying for the SAME unit
+//                    (redundant — these are wasted applications)
+//   3. splits      — (state, species) pairs where members have overlapping
+//                    interest but the group could spread across multiple
+//                    units to maximize "someone draws"
+// =============================================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, inArray } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import {
+  huntGroups,
+  huntGroupMembers,
+  playbooks,
+  recommendations,
+  states,
+  species,
+  huntUnits,
+  users,
+} from "@/lib/db/schema";
+
+interface MemberRec {
+  memberId: string;
+  memberEmail: string;
+  memberName: string;
+  recId: string;
+  stateCode: string;
+  speciesSlug: string;
+  speciesName: string;
+  unitCode: string | null;
+  recType: string;
+  rank: number;
+  score: number;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: groupId } = await params;
+
+  // Verify the caller is in the group (or owns it).
+  const [group] = await db
+    .select()
+    .from(huntGroups)
+    .where(eq(huntGroups.id, groupId))
+    .limit(1);
+  if (!group) {
+    return NextResponse.json({ error: "Group not found" }, { status: 404 });
+  }
+
+  const callerMembership = await db
+    .select()
+    .from(huntGroupMembers)
+    .where(
+      and(
+        eq(huntGroupMembers.groupId, groupId),
+        eq(huntGroupMembers.userId, session.user.id),
+      ),
+    )
+    .limit(1);
+
+  if (
+    callerMembership.length === 0 &&
+    group.ownerId !== session.user.id
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Get active members (those who have accepted the invite + linked a user).
+  const members = await db
+    .select({
+      memberId: huntGroupMembers.id,
+      email: huntGroupMembers.email,
+      userId: huntGroupMembers.userId,
+      displayName: users.displayName,
+    })
+    .from(huntGroupMembers)
+    .leftJoin(users, eq(huntGroupMembers.userId, users.id))
+    .where(
+      and(
+        eq(huntGroupMembers.groupId, groupId),
+        eq(huntGroupMembers.status, "active"),
+      ),
+    );
+
+  // Active playbooks for those members.
+  const memberUserIds = members
+    .map((m) => m.userId)
+    .filter((id): id is string => !!id);
+
+  if (memberUserIds.length === 0) {
+    return NextResponse.json({
+      memberCount: 0,
+      coverage: [],
+      overlap: [],
+      splitSuggestions: [],
+      note: "No active members with linked accounts yet.",
+    });
+  }
+
+  const activePlaybookRows = await db
+    .select({
+      playbookId: playbooks.id,
+      userId: playbooks.userId,
+    })
+    .from(playbooks)
+    .where(
+      and(
+        inArray(playbooks.userId, memberUserIds),
+        eq(playbooks.status, "active"),
+      ),
+    );
+
+  if (activePlaybookRows.length === 0) {
+    return NextResponse.json({
+      memberCount: members.length,
+      coverage: [],
+      overlap: [],
+      splitSuggestions: [],
+      note: "Members haven't generated playbooks yet.",
+    });
+  }
+
+  const playbookIds = activePlaybookRows.map((p) => p.playbookId);
+  const playbookOwner: Record<string, string> = {};
+  for (const p of activePlaybookRows) {
+    playbookOwner[p.playbookId] = p.userId;
+  }
+
+  // Top 5 recommendations per playbook.
+  const recRows = await db
+    .select({
+      id: recommendations.id,
+      playbookId: recommendations.playbookId,
+      stateCode: states.code,
+      speciesSlug: species.slug,
+      speciesName: species.commonName,
+      unitCode: huntUnits.unitCode,
+      recType: recommendations.recType,
+      rank: recommendations.rank,
+      score: recommendations.score,
+    })
+    .from(recommendations)
+    .innerJoin(states, eq(recommendations.stateId, states.id))
+    .innerJoin(species, eq(recommendations.speciesId, species.id))
+    .leftJoin(huntUnits, eq(recommendations.huntUnitId, huntUnits.id))
+    .where(inArray(recommendations.playbookId, playbookIds));
+
+  // Map recs back to members with display names.
+  const memberByUserId = new Map(
+    members.map((m) => [
+      m.userId ?? "_unknown",
+      {
+        email: m.email,
+        name: m.displayName || m.email.split("@")[0],
+      },
+    ]),
+  );
+
+  const memberRecs: MemberRec[] = [];
+  for (const r of recRows) {
+    const ownerUserId = playbookOwner[r.playbookId];
+    if (!ownerUserId) continue;
+    const profile = memberByUserId.get(ownerUserId);
+    if (!profile) continue;
+    memberRecs.push({
+      memberId: ownerUserId,
+      memberEmail: profile.email,
+      memberName: profile.name ?? profile.email,
+      recId: r.id,
+      stateCode: r.stateCode,
+      speciesSlug: r.speciesSlug,
+      speciesName: r.speciesName,
+      unitCode: r.unitCode ?? null,
+      recType: r.recType,
+      rank: r.rank ?? 99,
+      score: r.score ?? 0,
+    });
+  }
+
+  // ── Coverage: distinct (state, species) ──────────────────────────────────
+  type CoverageEntry = {
+    stateCode: string;
+    speciesSlug: string;
+    speciesName: string;
+    memberNames: string[];
+  };
+  const coverageMap = new Map<string, CoverageEntry>();
+  for (const r of memberRecs) {
+    const key = `${r.stateCode}|${r.speciesSlug}`;
+    const existing = coverageMap.get(key);
+    if (existing) {
+      if (!existing.memberNames.includes(r.memberName)) {
+        existing.memberNames.push(r.memberName);
+      }
+    } else {
+      coverageMap.set(key, {
+        stateCode: r.stateCode,
+        speciesSlug: r.speciesSlug,
+        speciesName: r.speciesName,
+        memberNames: [r.memberName],
+      });
+    }
+  }
+
+  // ── Overlap: (state, species, unit) where 2+ members compete ─────────────
+  type OverlapEntry = {
+    stateCode: string;
+    speciesSlug: string;
+    speciesName: string;
+    unitCode: string | null;
+    members: string[];
+  };
+  const overlapMap = new Map<string, OverlapEntry>();
+  for (const r of memberRecs) {
+    if (!r.unitCode) continue; // can't detect unit-level overlap without a unit
+    const key = `${r.stateCode}|${r.speciesSlug}|${r.unitCode}`;
+    const existing = overlapMap.get(key);
+    if (existing) {
+      if (!existing.members.includes(r.memberName)) {
+        existing.members.push(r.memberName);
+      }
+    } else {
+      overlapMap.set(key, {
+        stateCode: r.stateCode,
+        speciesSlug: r.speciesSlug,
+        speciesName: r.speciesName,
+        unitCode: r.unitCode,
+        members: [r.memberName],
+      });
+    }
+  }
+  const overlap = Array.from(overlapMap.values()).filter(
+    (o) => o.members.length >= 2,
+  );
+
+  // ── Split suggestions: (state, species) where 2+ members all target the
+  // same unit could instead spread across multiple units ───────────────────
+  type SplitEntry = {
+    stateCode: string;
+    speciesSlug: string;
+    speciesName: string;
+    members: string[];
+    currentUnit: string | null;
+    suggestion: string;
+  };
+  const splitSuggestions: SplitEntry[] = overlap.map((o) => ({
+    stateCode: o.stateCode,
+    speciesSlug: o.speciesSlug,
+    speciesName: o.speciesName,
+    members: o.members,
+    currentUnit: o.unitCode,
+    suggestion:
+      o.members.length === 2
+        ? `Both ${o.members.join(" and ")} are applying for ${o.stateCode} ${o.speciesName} Unit ${o.unitCode}. Consider splitting across two units to double the group's chances — whoever draws hosts.`
+        : `${o.members.length} members are all applying for ${o.stateCode} ${o.speciesName} Unit ${o.unitCode}. Spread across ${o.members.length} different units (one per member) for ${o.members.length}× the coverage.`,
+  }));
+
+  return NextResponse.json({
+    memberCount: members.length,
+    coverage: Array.from(coverageMap.values()).sort((a, b) =>
+      a.stateCode.localeCompare(b.stateCode),
+    ),
+    overlap,
+    splitSuggestions,
+  });
+}

--- a/src/app/api/v1/groups/[id]/strategy/route.ts
+++ b/src/app/api/v1/groups/[id]/strategy/route.ts
@@ -142,8 +142,16 @@ export async function GET(
     playbookOwner[p.playbookId] = p.userId;
   }
 
-  // Top 5 recommendations per playbook.
-  const recRows = await db
+  // Pull every recommendation for the active playbooks, then enforce the
+  // top-N-per-playbook cap in-memory. Review feedback (PR #21): the
+  // original implementation said "Top 5 recommendations per playbook" but
+  // the SQL had no rank cutoff, so coverage/overlap/split outputs were
+  // inflated by long-tail recs that members weren't actually prioritizing.
+  // Doing the cap in code keeps the SQL simple — we don't need to write a
+  // window function — and the row volume is small (active playbooks ×
+  // active members for one group).
+  const TOP_N_PER_PLAYBOOK = 5;
+  const allRecRows = await db
     .select({
       id: recommendations.id,
       playbookId: recommendations.playbookId,
@@ -160,6 +168,21 @@ export async function GET(
     .innerJoin(species, eq(recommendations.speciesId, species.id))
     .leftJoin(huntUnits, eq(recommendations.huntUnitId, huntUnits.id))
     .where(inArray(recommendations.playbookId, playbookIds));
+
+  // Enforce the top-N-per-playbook cap. Lower `rank` integers = higher
+  // priority; null ranks sink to the bottom so they only show up if a
+  // playbook has fewer than N ranked recs.
+  const recsByPlaybook = new Map<string, typeof allRecRows>();
+  for (const r of allRecRows) {
+    const bucket = recsByPlaybook.get(r.playbookId) ?? [];
+    bucket.push(r);
+    recsByPlaybook.set(r.playbookId, bucket);
+  }
+  const recRows: typeof allRecRows = [];
+  for (const bucket of recsByPlaybook.values()) {
+    bucket.sort((a, b) => (a.rank ?? 999) - (b.rank ?? 999));
+    recRows.push(...bucket.slice(0, TOP_N_PER_PLAYBOOK));
+  }
 
   // Map recs back to members with display names.
   const memberByUserId = new Map(

--- a/src/components/groups/GroupStrategyView.tsx
+++ b/src/components/groups/GroupStrategyView.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Compass, AlertTriangle, GitBranch } from "lucide-react";
+
+interface CoverageEntry {
+  stateCode: string;
+  speciesSlug: string;
+  speciesName: string;
+  memberNames: string[];
+}
+
+interface OverlapEntry {
+  stateCode: string;
+  speciesSlug: string;
+  speciesName: string;
+  unitCode: string | null;
+  members: string[];
+}
+
+interface SplitEntry {
+  stateCode: string;
+  speciesSlug: string;
+  speciesName: string;
+  members: string[];
+  currentUnit: string | null;
+  suggestion: string;
+}
+
+interface StrategyResponse {
+  memberCount: number;
+  coverage: CoverageEntry[];
+  overlap: OverlapEntry[];
+  splitSuggestions: SplitEntry[];
+  note?: string;
+}
+
+/**
+ * Renders the "joint application strategy" section on a hunt group's detail
+ * page. Pulls the per-member playbook overlap analysis from the strategy
+ * API and surfaces it as three distinct lenses:
+ *
+ *   1. Coverage — what hunts the group collectively targets
+ *   2. Overlap  — duplicate applications (multiple members on the same unit)
+ *   3. Splits   — actionable suggestions to spread across more units
+ *
+ * Self-contained: own loading + error states. Renders a friendly note
+ * when members haven't generated playbooks yet (the most common empty
+ * state for a brand-new group).
+ */
+export function GroupStrategyView({ groupId }: { groupId: string }) {
+  const [data, setData] = useState<StrategyResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/v1/groups/${groupId}/strategy`);
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const json = (await res.json()) as StrategyResponse;
+        if (!cancelled) setData(json);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId]);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-brand-sage/10 bg-white p-5 shadow-sm dark:border-brand-sage/20 dark:bg-brand-bark">
+        <div className="h-5 w-40 motion-safe:animate-pulse rounded-lg bg-brand-sage/10" />
+        <div className="mt-3 h-16 motion-safe:animate-pulse rounded-lg bg-brand-sage/10" />
+      </div>
+    );
+  }
+  if (error || !data) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        Failed to load joint strategy. {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-brand-sage/10 bg-white p-5 shadow-sm dark:border-brand-sage/20 dark:bg-brand-bark">
+      <div className="mb-3 flex items-center gap-2">
+        <Compass className="h-4 w-4 text-brand-forest" />
+        <h2 className="text-sm font-semibold text-brand-bark dark:text-brand-cream">
+          Joint application strategy
+        </h2>
+      </div>
+
+      {data.note && (
+        <p className="mb-3 rounded-md bg-brand-sage/5 px-3 py-2 text-xs italic text-brand-sage dark:bg-brand-sage/10">
+          {data.note}
+        </p>
+      )}
+
+      {/* Coverage */}
+      <section className="mb-4">
+        <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-brand-sage">
+          Coverage ({data.coverage.length} hunts)
+        </h3>
+        {data.coverage.length === 0 ? (
+          <p className="text-sm text-brand-sage">
+            Once members generate playbooks, the group&apos;s collective targets
+            show up here.
+          </p>
+        ) : (
+          <ul className="flex flex-wrap gap-1.5">
+            {data.coverage.map((c) => (
+              <li
+                key={`${c.stateCode}-${c.speciesSlug}`}
+                className="flex items-center gap-1 rounded-md border border-brand-sage/15 bg-brand-sage/5 px-2 py-0.5 text-xs text-brand-bark dark:border-brand-sage/25 dark:bg-brand-sage/10 dark:text-brand-cream"
+                title={`Members: ${c.memberNames.join(", ")}`}
+              >
+                <span className="font-mono text-[10px] text-brand-sage">
+                  {c.stateCode}
+                </span>
+                <span>{c.speciesName}</span>
+                <span className="text-[10px] text-brand-sage/60">
+                  ({c.memberNames.length})
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Overlap */}
+      {data.overlap.length > 0 && (
+        <section className="mb-4">
+          <h3 className="mb-2 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-amber-700">
+            <AlertTriangle className="h-3 w-3" />
+            Duplicate applications ({data.overlap.length})
+          </h3>
+          <ul className="space-y-1.5">
+            {data.overlap.map((o) => (
+              <li
+                key={`${o.stateCode}-${o.speciesSlug}-${o.unitCode}`}
+                className="rounded-md border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200"
+              >
+                <span className="font-mono text-[10px]">{o.stateCode}</span>{" "}
+                {o.speciesName} Unit {o.unitCode} — {o.members.join(" and ")}{" "}
+                applying for the same tag.
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Splits */}
+      {data.splitSuggestions.length > 0 && (
+        <section>
+          <h3 className="mb-2 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-brand-forest">
+            <GitBranch className="h-3 w-3" />
+            Suggested splits ({data.splitSuggestions.length})
+          </h3>
+          <ul className="space-y-2">
+            {data.splitSuggestions.map((s, i) => (
+              <li
+                key={`${s.stateCode}-${s.speciesSlug}-${i}`}
+                className="rounded-md border border-brand-forest/20 bg-brand-forest/5 px-3 py-2 text-xs text-brand-bark dark:border-brand-sage/30 dark:bg-brand-sage/10 dark:text-brand-cream"
+              >
+                {s.suggestion}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Hunt Groups had CRUD (create, list, invite, plans) but no actual **group strategy**. The original ask was *"you apply unit 12, I apply unit 14, whoever draws hosts"* — coordinating across members so a group spreads its applications instead of duplicating them.

## What ships

**`GET /api/v1/groups/[id]/strategy`** — aggregates each active member's active playbook recommendations into:
1. **Coverage** — distinct (state, species) the group targets
2. **Overlap** — (state, species, unit) where 2+ members compete for the same tag
3. **Splits** — actionable suggestion text per overlap row

Membership-gated. Returns a friendly note when members haven't generated playbooks yet.

**`<GroupStrategyView />`** — new component, self-fetching, renders the three lenses with color-coded callouts (amber = duplicate applications, forest = suggested splits).

Wired into `/groups/[id]` above the Hunt Plans section.

## Test plan

- [ ] Create a group with 2+ members who have playbooks generated
- [ ] Strategy panel renders with coverage chips and any overlaps highlighted
- [ ] If two members both have NV Elk Unit 12 in their top recs → "Duplicate applications" row + a split suggestion
- [ ] Group with no playbook-generating members → friendly empty-state note

🤖 Generated with [Claude Code](https://claude.com/claude-code)