### PR TITLE
docs(checkout): auto-apply audit + smoke tests + runbook (NOT activation)

### DIFF
--- a/docs/AUTO_APPLY_AUDIT.md
+++ b/docs/AUTO_APPLY_AUDIT.md
@@ -1,0 +1,186 @@
+# Auto-Apply / Concierge Checkout Audit
+
+**As of:** May 21, 2026
+**Status:** Code path exists end-to-end but has **never been tested with a real Stripe charge**. Do not expose to additional surfaces until the manual test runbook below has been completed.
+
+---
+
+## What's built
+
+### Database (already migrated)
+
+- `application_orders` — parent order (one per checkout)
+- `application_order_items` — individual applications within an order
+- `payments` — Stripe payment records
+- `refunds` — refund tracking
+- `state_fee_schedules` — per-state per-species per-year fees
+- `service_fee_config` — HuntLogic's service fees per tier
+- `state_form_configs` — dynamic form schemas (per state/species/year)
+- `fulfillment_logs` — ops audit trail
+- `opsUsers` — internal ops team accounts
+
+### API routes (already deployed)
+
+**Customer-facing (`/api/v1/concierge/orders/*`):**
+- `GET /` — list user's orders
+- `POST /` — create draft order
+- `GET /[orderId]` — read order detail
+- `GET /[orderId]/status` — current state of order
+- `POST /[orderId]/items` — add item (recommendation) to order
+- `DELETE /[orderId]/items/[itemId]` — remove item
+- `POST /[orderId]/checkout` — create Stripe Checkout Session
+- `POST /[orderId]/link-credentials` — link state agency creds for the order
+
+**Ops-facing (`/api/v1/ops/orders/*`):**
+- `GET /` — queue view
+- `GET /[orderId]` — order detail with items + logs
+- `POST /[orderId]/assign` — assign to an ops user
+- `PATCH /[orderId]/items/[itemId]` — update item status (queued → in_progress → submitted)
+- `POST /[orderId]/items/[itemId]/log` — append fulfillment log entry
+- `POST /[orderId]/items/[itemId]/refund` — initiate Stripe refund
+
+**Stripe webhook (`/api/webhooks/stripe`):**
+Handles 5 event types: `checkout.session.completed`, `payment_intent.succeeded`, `payment_intent.payment_failed`, `charge.refunded`, `charge.dispute.created`.
+
+### UI
+
+- `/orders` — list page
+- `/orders/cart` — cart with line items, residency picker, total, "Pay now" button (921 LOC — substantial)
+- `/orders/[orderId]` — order detail with item status (464 LOC)
+- `/orders/success` — Stripe success redirect target
+- `/orders/cancelled` — Stripe cancel redirect target
+- `Apply For Me` button on `RecommendationCard` (wired only from `/recommendations` so far)
+
+---
+
+## Gaps + risks identified during audit
+
+### 🔴 Critical (block production exposure)
+
+1. **Fulfillment never enqueues a job** — `handleCheckoutSessionCompleted` at `src/app/api/webhooks/stripe/route.ts:218` logs `"fulfillment queued"` but actually does nothing. Comment reads: *"In production this would enqueue a BullMQ job; for now we log it."* **Without an actual queue, ops users must poll `/api/v1/ops/orders` to find paid orders to work on.**
+
+2. **End-to-end flow has never been tested with a real Stripe transaction.** The signature verification path, idempotency on retried webhooks, and the cart UI's interaction with the API have not been validated.
+
+3. **No state fee data is seeded.** The cart total depends on `application_order_items.state_fee` and `service_fee`, which depend on the (unseeded?) `state_fee_schedules` and `service_fee_config` tables. **A zero-total cart is rejected at checkout, so the flow may fail at "Pay now" with an unhelpful error.** Confirmed by checkout route logic (`src/app/api/v1/concierge/orders/[orderId]/checkout/route.ts:119`).
+
+4. **No "test mode" indicator on orders.** When Stripe is in test mode, orders look identical to real orders — ops could attempt to fulfill a test order. Recommend adding an `is_test_mode` field or label.
+
+### 🟡 Medium (should fix before scaling)
+
+5. **`disputed` status not in original schema enum.** Webhook writes `"disputed" as string` at `route.ts:529`. Schema comment updated in this PR but no DB constraint enforces it. Ops queries filtering by status need to include this value.
+
+6. **No idempotency keys on Stripe API calls.** `stripe.checkout.sessions.create` and `stripe.refunds.create` can race-create duplicates if the client retries. Add idempotency keys derived from `orderId` + action.
+
+7. **Webhook returns 200 on internal errors.** Intentional to prevent Stripe retries, but masks failures. Add: a `webhook_event_log` table or at minimum a Sentry/PostHog event so silent failures are visible.
+
+8. **`stripePaymentIntentId` is stored as `null` on checkout creation** (`route.ts:143`). Stripe Checkout Sessions don't have a payment_intent until they complete; the field is updated later from the webhook. Not incorrect, but the order shows a misleading "pending" state with no PI for the user's reference.
+
+9. **No automatic tax handling.** Stripe Checkout supports `automatic_tax: { enabled: true }`. Should add if you'll be charging sales tax on the service fee.
+
+### 🟢 Minor (polish)
+
+10. **`Apply For Me` only wired into `/recommendations`** — not into `/playbook` or `/profile/strategy`. **Deliberately NOT shipped in this PR** until the end-to-end flow is verified.
+
+11. **No way for ops to see the original recommendation context.** `application_order_items.recommendation_id` is set, but ops UI doesn't expand it to show "user picked this because: [scoring factors]".
+
+12. **No "ready to apply" preflight check.** A user could checkout for a hunt whose application window already closed. Add a per-item validation that the deadline is in the future.
+
+13. **Refund partial-vs-full status tracking** — when a partial refund happens, payment status becomes `"partially_refunded"` but order status stays `"paid"`. May want a `partial_refund` order status.
+
+---
+
+## Manual test runbook
+
+**Prereqs (set once):**
+
+1. **Stripe test mode** keys in Vercel:
+   ```
+   STRIPE_SECRET_KEY=sk_test_...
+   STRIPE_WEBHOOK_SECRET=whsec_...        # from Stripe Dashboard → Webhooks
+   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+   ```
+2. **Stripe CLI** for local webhook forwarding (only needed for local testing):
+   ```bash
+   brew install stripe/stripe-cli/stripe
+   stripe login
+   stripe listen --forward-to https://huntlogic.vercel.app/api/webhooks/stripe
+   ```
+3. **Seed at least one state_fee_schedule row** so the cart total isn't zero. (Future PR: seed all states.)
+
+**Test 1 — Happy path (test card 4242 4242 4242 4242):**
+
+1. Sign in as a real (non-admin) test user.
+2. Open `/recommendations`, click **Apply For Me** on any recommendation.
+3. Land on `/orders/cart`. Verify:
+   - Line items list the picked hunt with state name + species name.
+   - Total > $0.
+   - Residency selector defaults to `nonresident`.
+4. Click **Pay now**. Verify redirect to `checkout.stripe.com`.
+5. Enter test card `4242 4242 4242 4242`, any future expiry, any CVC.
+6. Submit. Verify:
+   - Redirect to `/orders/success?orderId=...&session_id=...`
+   - Within 30 seconds, the order detail page shows status `paid`.
+   - In Stripe Dashboard → Webhooks, verify the `checkout.session.completed` event was delivered with HTTP 200.
+   - DB check: `application_orders.status = 'paid'`, `payments` row created, `application_order_items.status = 'queued'`, `fulfillment_logs` has a `payment_received` row.
+7. **Notification check:** verify the user received an in-app + email notification ("Payment Confirmed").
+
+**Test 2 — Cancelled checkout:**
+
+1. From cart, click **Pay now**.
+2. On Stripe Checkout, click the back arrow.
+3. Verify redirect to `/orders/cancelled?orderId=...` and order status remains `pending_payment`.
+4. Verify user can return to `/orders/[orderId]`, edit items, and re-checkout.
+
+**Test 3 — Declined card (test card 4000 0000 0000 0002):**
+
+1. From cart, click **Pay now**.
+2. On Stripe Checkout, enter card `4000 0000 0000 0002` (always declined).
+3. Verify error shown by Stripe.
+4. Verify `payment_intent.payment_failed` event delivered to webhook.
+5. Verify `application_orders.status = 'cancelled'` and a `payment_failed` notification fired.
+
+**Test 4 — Refund (ops flow):**
+
+1. From an `is_test_mode` paid order, call `POST /api/v1/ops/orders/[orderId]/items/[itemId]/refund` with `{ amount: <full> }`.
+2. Verify Stripe Dashboard shows the refund.
+3. Verify `charge.refunded` webhook fires and creates a `refunds` row.
+4. Verify `payments.status = 'refunded'` and `application_orders.status = 'refunded'`.
+
+**Test 5 — Webhook signature mismatch:**
+
+1. `curl -X POST` to `/api/webhooks/stripe` with a body but no `stripe-signature` header.
+2. Verify HTTP 400 with "Missing stripe-signature header".
+3. `curl -X POST` with a bogus signature header.
+4. Verify HTTP 400 with "Webhook signature verification failed: ...".
+
+**Test 6 — Webhook idempotency:**
+
+1. After a successful payment, manually re-fire the `checkout.session.completed` event from Stripe Dashboard → Webhooks → Event detail → Resend.
+2. Verify the second invocation logs `"Order ... already in status 'paid', skipping"` and does NOT create a duplicate payment row.
+
+---
+
+## Recommended order of operations to go live
+
+1. ✅ Apply this PR (audit + smoke tests + schema comment fix).
+2. **Seed `state_fee_schedules` and `service_fee_config`** so carts have non-zero totals.
+3. **Run the 6-step test runbook above** in Stripe test mode.
+4. **Wire the actual fulfillment queue** — replace the `console.log` at `route.ts:218-223` with a BullMQ job. The job processor lives in the existing `src/services/ingestion/workers/` pattern.
+5. **Add ops UI in `/admin/orders` or `/ops/orders`** — currently only API routes exist; ops users have no in-app view to work the queue.
+6. **Only then** wire `Apply For Me` into `/playbook` and `/profile/strategy`.
+
+---
+
+## What this PR ships
+
+- This document.
+- Schema comment fix for `disputed` status.
+- Unit tests for `generateOrderNumber` (format) and `buildCheckoutUrls` (URL construction).
+- A `tests/auto-apply-state-machine.test.ts` that exercises the webhook idempotency check logic in isolation (no Stripe API calls).
+
+**What this PR explicitly does NOT do:**
+
+- No new activation surfaces (Playbook, Annual Strategy).
+- No live Stripe integration tests.
+- No fulfillment queue implementation.
+- No ops UI.

--- a/src/app/api/v1/concierge/orders/[orderId]/checkout/route.ts
+++ b/src/app/api/v1/concierge/orders/[orderId]/checkout/route.ts
@@ -17,6 +17,7 @@ import {
   createCheckoutSession,
   generateOrderNumber,
 } from "@/services/stripe";
+import { canCheckout } from "@/services/stripe/predicates";
 import { config } from "@/lib/config";
 
 const LOG_PREFIX = "[api:concierge/orders/[orderId]/checkout]";
@@ -45,7 +46,9 @@ export async function POST(
       return NextResponse.json({ error: "Order not found" }, { status: 404 });
     }
 
-    if (order.status !== "draft") {
+    // Predicate is in services/stripe/predicates.ts so tests exercise the
+    // same logic the route enforces.
+    if (!canCheckout(order.status)) {
       return NextResponse.json(
         { error: "Only draft orders can be checked out" },
         { status: 400 }

--- a/src/app/api/webhooks/stripe/__tests__/idempotency.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/idempotency.test.ts
@@ -1,0 +1,111 @@
+// Webhook idempotency smoke test.
+//
+// Stripe retries webhooks aggressively on non-2xx, and even on 2xx can
+// re-fire the same event (delivery attempt 2, 3, ...). The webhook
+// handler must be safe to invoke twice with the same event.
+//
+// This test models the small piece of decision logic that lives inside
+// handleCheckoutSessionCompleted: "if order status is already 'paid' or
+// 'in_progress', skip." It's deliberately a unit test on the predicate
+// rather than a full integration test — the latter requires Drizzle +
+// Stripe SDK mocking, which is out of scope for this PR. See
+// docs/AUTO_APPLY_AUDIT.md "Test 6" for the end-to-end variant.
+
+import { describe, it, expect } from "vitest";
+
+/**
+ * Mirror of the in-handler idempotency check at:
+ *   src/app/api/webhooks/stripe/route.ts:146
+ *
+ * Exposed as a pure function here so we can lock it down with tests
+ * without spinning up the full webhook handler.
+ */
+function shouldSkipDuplicateCheckout(orderStatus: string): boolean {
+  return orderStatus === "paid" || orderStatus === "in_progress";
+}
+
+describe("checkout.session.completed idempotency", () => {
+  it("skips when order is already paid", () => {
+    expect(shouldSkipDuplicateCheckout("paid")).toBe(true);
+  });
+
+  it("skips when order is in_progress (ops has started)", () => {
+    expect(shouldSkipDuplicateCheckout("in_progress")).toBe(true);
+  });
+
+  it("processes when order is pending_payment (first delivery)", () => {
+    expect(shouldSkipDuplicateCheckout("pending_payment")).toBe(false);
+  });
+
+  it("processes when order is draft (degenerate but possible)", () => {
+    expect(shouldSkipDuplicateCheckout("draft")).toBe(false);
+  });
+
+  it("processes when order is cancelled (rescue path: re-paying a cancelled order)", () => {
+    // If a user managed to re-checkout a cancelled order, the webhook
+    // should still process. The handler then moves it back to 'paid'.
+    expect(shouldSkipDuplicateCheckout("cancelled")).toBe(false);
+  });
+
+  it("processes when order has the new 'disputed' status", () => {
+    // 'disputed' is set by charge.dispute.created. A retried checkout
+    // event after a dispute is unusual but shouldn't be silently dropped.
+    expect(shouldSkipDuplicateCheckout("disputed")).toBe(false);
+  });
+});
+
+/**
+ * Mirror of the partial-vs-full refund predicate at:
+ *   src/app/api/webhooks/stripe/route.ts:455
+ */
+function isFullRefund(args: {
+  refunded: boolean;
+  amountRefunded: number;
+  amount: number;
+}): boolean {
+  return args.refunded && args.amountRefunded === args.amount;
+}
+
+describe("charge.refunded full-vs-partial", () => {
+  it("flags as full when refunded=true AND amounts equal", () => {
+    expect(isFullRefund({ refunded: true, amountRefunded: 10000, amount: 10000 })).toBe(true);
+  });
+
+  it("flags as partial when refunded=true but amount_refunded < amount", () => {
+    expect(isFullRefund({ refunded: true, amountRefunded: 5000, amount: 10000 })).toBe(false);
+  });
+
+  it("flags as partial when refunded=false even with matching amounts", () => {
+    // Edge case: defensive — if Stripe says refunded=false we treat as partial.
+    expect(isFullRefund({ refunded: false, amountRefunded: 10000, amount: 10000 })).toBe(false);
+  });
+});
+
+/**
+ * Mirror of the checkout precondition at:
+ *   src/app/api/v1/concierge/orders/[orderId]/checkout/route.ts:48
+ *
+ * Only draft orders can be checked out — protects against double-charging
+ * the same order after a successful payment.
+ */
+function canCheckout(orderStatus: string): boolean {
+  return orderStatus === "draft";
+}
+
+describe("checkout precondition", () => {
+  it("allows draft orders", () => {
+    expect(canCheckout("draft")).toBe(true);
+  });
+  it.each([
+    "pending_payment",
+    "paid",
+    "in_progress",
+    "submitted",
+    "completed",
+    "cancelled",
+    "refunded",
+    "disputed",
+  ])("rejects status=%s", (status) => {
+    expect(canCheckout(status)).toBe(false);
+  });
+});

--- a/src/app/api/webhooks/stripe/__tests__/idempotency.test.ts
+++ b/src/app/api/webhooks/stripe/__tests__/idempotency.test.ts
@@ -1,28 +1,24 @@
-// Webhook idempotency smoke test.
+// Webhook + checkout decision-point regression tests.
 //
 // Stripe retries webhooks aggressively on non-2xx, and even on 2xx can
-// re-fire the same event (delivery attempt 2, 3, ...). The webhook
-// handler must be safe to invoke twice with the same event.
+// re-fire the same event (delivery attempt 2, 3, ...). The handler must
+// be safe to invoke twice with the same event.
 //
-// This test models the small piece of decision logic that lives inside
-// handleCheckoutSessionCompleted: "if order status is already 'paid' or
-// 'in_progress', skip." It's deliberately a unit test on the predicate
-// rather than a full integration test — the latter requires Drizzle +
-// Stripe SDK mocking, which is out of scope for this PR. See
-// docs/AUTO_APPLY_AUDIT.md "Test 6" for the end-to-end variant.
+// Review feedback on PR #22: an earlier version of this file
+// reimplemented `shouldSkipDuplicateCheckout`, `isFullRefund`, and
+// `canCheckout` *inside the test file*, which meant the tests could
+// stay green while the production code drifted. Fixed by extracting
+// those predicates into `services/stripe/predicates.ts` and importing
+// them here — the webhook (`route.ts`) and checkout route
+// (`concierge/orders/[orderId]/checkout/route.ts`) both call the same
+// exported functions, so any drift in behavior is caught by this suite.
 
 import { describe, it, expect } from "vitest";
-
-/**
- * Mirror of the in-handler idempotency check at:
- *   src/app/api/webhooks/stripe/route.ts:146
- *
- * Exposed as a pure function here so we can lock it down with tests
- * without spinning up the full webhook handler.
- */
-function shouldSkipDuplicateCheckout(orderStatus: string): boolean {
-  return orderStatus === "paid" || orderStatus === "in_progress";
-}
+import {
+  shouldSkipDuplicateCheckout,
+  isFullRefund,
+  canCheckout,
+} from "@/services/stripe/predicates";
 
 describe("checkout.session.completed idempotency", () => {
   it("skips when order is already paid", () => {
@@ -54,18 +50,6 @@ describe("checkout.session.completed idempotency", () => {
   });
 });
 
-/**
- * Mirror of the partial-vs-full refund predicate at:
- *   src/app/api/webhooks/stripe/route.ts:455
- */
-function isFullRefund(args: {
-  refunded: boolean;
-  amountRefunded: number;
-  amount: number;
-}): boolean {
-  return args.refunded && args.amountRefunded === args.amount;
-}
-
 describe("charge.refunded full-vs-partial", () => {
   it("flags as full when refunded=true AND amounts equal", () => {
     expect(isFullRefund({ refunded: true, amountRefunded: 10000, amount: 10000 })).toBe(true);
@@ -80,17 +64,6 @@ describe("charge.refunded full-vs-partial", () => {
     expect(isFullRefund({ refunded: false, amountRefunded: 10000, amount: 10000 })).toBe(false);
   });
 });
-
-/**
- * Mirror of the checkout precondition at:
- *   src/app/api/v1/concierge/orders/[orderId]/checkout/route.ts:48
- *
- * Only draft orders can be checked out — protects against double-charging
- * the same order after a successful payment.
- */
-function canCheckout(orderStatus: string): boolean {
-  return orderStatus === "draft";
-}
 
 describe("checkout precondition", () => {
   it("allows draft orders", () => {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -20,6 +20,10 @@ import {
 import { eq, and } from "drizzle-orm";
 import { constructWebhookEvent } from "@/services/stripe";
 import {
+  shouldSkipDuplicateCheckout,
+  isFullRefund as computeIsFullRefund,
+} from "@/services/stripe/predicates";
+import {
   notifyOrderPaid,
   notifyPaymentFailed,
   createNotification,
@@ -142,8 +146,10 @@ async function handleCheckoutSessionCompleted(
     return;
   }
 
-  // Idempotency: skip if already paid
-  if (order.status === "paid" || order.status === "in_progress") {
+  // Idempotency: skip if already paid. The predicate lives in
+  // services/stripe/predicates.ts so the unit tests in
+  // app/api/webhooks/stripe/__tests__ exercise the same code.
+  if (shouldSkipDuplicateCheckout(order.status)) {
     console.log(
       `[stripe-webhook] Order ${orderId} already in status '${order.status}', skipping`
     );
@@ -451,8 +457,13 @@ async function handleChargeRefunded(charge: Stripe.Charge) {
     });
   }
 
-  // Determine if full or partial refund
-  const isFullRefund = charge.refunded && charge.amount_refunded === charge.amount;
+  // Determine if full or partial refund (predicate is in
+  // services/stripe/predicates.ts so tests exercise the same logic).
+  const isFullRefund = computeIsFullRefund({
+    refunded: charge.refunded ?? false,
+    amountRefunded: charge.amount_refunded,
+    amount: charge.amount,
+  });
 
   // Update payment status
   await db

--- a/src/lib/db/schema/concierge.ts
+++ b/src/lib/db/schema/concierge.ts
@@ -114,7 +114,11 @@ export const applicationOrders = pgTable(
     }),
     year: integer("year").notNull(),
     tier: text("tier").notNull(), // 'scout' | 'pro' | 'elite'
-    status: text("status").notNull().default("draft"), // 'draft' | 'pending_payment' | 'paid' | 'in_progress' | 'submitted' | 'completed' | 'cancelled' | 'refunded'
+    // 'draft' | 'pending_payment' | 'paid' | 'in_progress' | 'submitted'
+    // | 'completed' | 'cancelled' | 'refunded' | 'disputed'
+    // (the webhook writes 'disputed' when Stripe fires charge.dispute.created;
+    // ops queues should treat it as a hold state requiring manual review.)
+    status: text("status").notNull().default("draft"),
     stateFeeTotal: decimal("state_fee_total", { precision: 10, scale: 2 })
       .notNull()
       .default("0"),

--- a/src/services/stripe/__tests__/helpers.test.ts
+++ b/src/services/stripe/__tests__/helpers.test.ts
@@ -1,0 +1,55 @@
+// Pure-function smoke tests for the Stripe service helpers. These do NOT
+// hit the Stripe API — they exist to catch regressions on the
+// non-network-dependent parts of the checkout path.
+
+import { describe, it, expect } from "vitest";
+
+// We have to import the helpers individually so the module's eager
+// Stripe client init (which reads STRIPE_SECRET_KEY from env) doesn't
+// fire during test collection.
+import {
+  generateOrderNumber,
+  buildCheckoutUrls,
+} from "../index";
+
+describe("generateOrderNumber", () => {
+  it("matches the HL-YYYY-NNNNN format", () => {
+    const n = generateOrderNumber();
+    expect(n).toMatch(/^HL-\d{4}-\d{5}$/);
+  });
+
+  it("embeds the current year", () => {
+    const n = generateOrderNumber();
+    const year = new Date().getFullYear().toString();
+    expect(n.startsWith(`HL-${year}-`)).toBe(true);
+  });
+
+  it("produces distinct numbers across multiple calls (collision-rare)", () => {
+    // 100 random 5-digit numbers should not all be the same. This is a
+    // sanity check on the random generation; collisions are still possible
+    // and the caller is responsible for handling them at write time.
+    const numbers = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      numbers.add(generateOrderNumber());
+    }
+    // We expect at least 90 distinct values out of 100 (margin for chance).
+    expect(numbers.size).toBeGreaterThan(90);
+  });
+});
+
+describe("buildCheckoutUrls", () => {
+  it("builds success + cancel URLs from app.url config", () => {
+    const urls = buildCheckoutUrls("order-abc-123");
+    expect(urls.successUrl).toMatch(/\/orders\/success\?orderId=order-abc-123$/);
+    expect(urls.cancelUrl).toMatch(/\/orders\/cancelled\?orderId=order-abc-123$/);
+  });
+
+  it("URL-encodes nothing surprising in a UUID-shaped order id", () => {
+    const urls = buildCheckoutUrls(
+      "ad8c8e6e-1a2b-4c5d-9e0f-aabbccddeeff",
+    );
+    expect(urls.successUrl).toContain(
+      "orderId=ad8c8e6e-1a2b-4c5d-9e0f-aabbccddeeff",
+    );
+  });
+});

--- a/src/services/stripe/predicates.ts
+++ b/src/services/stripe/predicates.ts
@@ -1,0 +1,60 @@
+// =============================================================================
+// Webhook + checkout decision predicates
+// =============================================================================
+// These pure-function predicates are the decision points the Stripe webhook
+// and checkout route use to decide whether to act on an event. They live
+// here (rather than inline in the route files) so that unit tests can
+// exercise the same code the production handlers run — review feedback on
+// PR #22 flagged that the previous tests reimplemented these predicates
+// inside the test file, which meant the tests could stay green while the
+// production code drifted.
+//
+// Keep this file pure: no DB, no Stripe API, no auth — just decisions
+// derived from already-fetched state.
+// =============================================================================
+
+/**
+ * Should this `checkout.session.completed` webhook delivery be skipped
+ * because the order has already advanced past the payment-received state?
+ *
+ * Stripe retries webhooks aggressively. The handler MUST be safe to invoke
+ * twice with the same event. We treat 'paid' and 'in_progress' as terminal-
+ * for-this-purpose: don't re-record payment, don't re-queue fulfillment.
+ *
+ * Used in: src/app/api/webhooks/stripe/route.ts (handleCheckoutSessionCompleted)
+ */
+export function shouldSkipDuplicateCheckout(orderStatus: string): boolean {
+  return orderStatus === "paid" || orderStatus === "in_progress";
+}
+
+/**
+ * Given a `charge.refunded` payload, is this a full or partial refund?
+ *
+ * Defensive: requires BOTH the `refunded` boolean from Stripe AND the
+ * amounts to match. If Stripe says refunded=false we treat it as partial
+ * regardless of the amounts (this protects against transient state where
+ * the refund flag hasn't caught up yet).
+ *
+ * Used in: src/app/api/webhooks/stripe/route.ts (handleChargeRefunded)
+ */
+export function isFullRefund(args: {
+  refunded: boolean;
+  amountRefunded: number;
+  amount: number;
+}): boolean {
+  return args.refunded && args.amountRefunded === args.amount;
+}
+
+/**
+ * Can this order start a Stripe Checkout session right now?
+ *
+ * Only 'draft' orders are eligible. Any other status means the order is
+ * already mid-flight (pending_payment, paid, in_progress, ...) or
+ * terminal (cancelled, refunded, disputed). Re-checking out a non-draft
+ * order would double-charge the user.
+ *
+ * Used in: src/app/api/v1/concierge/orders/[orderId]/checkout/route.ts
+ */
+export function canCheckout(orderStatus: string): boolean {
+  return orderStatus === "draft";
+}


### PR DESCRIPTION
## Summary

The auto-apply / concierge checkout flow is **more built than expected** (7 customer routes, 6 ops routes, full Stripe webhook handler, 1580 LOC of order UI), but has **never been tested with a real Stripe charge**. Rather than ship more activation surfaces into an unverified payment flow, this PR ships the safety scaffolding instead.

## What's in

### Audit doc: `docs/AUTO_APPLY_AUDIT.md`
Full architecture map, 13 prioritized gaps, and a 6-test manual runbook for verifying the flow end-to-end with Stripe test mode.

**Critical gaps flagged:**
1. Fulfillment "queue" is just `console.log` — ops must poll `/api/v1/ops/orders` manually to find paid orders
2. Flow has never been tested with a real Stripe charge
3. No `state_fee_schedules` / `service_fee_config` seed → cart total can be $0 → checkout rejects with an unhelpful error
4. No "test mode" indicator on orders — risk of ops fulfilling a test transaction

### Schema comment fix
`concierge.ts` order status enum now documents `'disputed'` (the webhook already writes this value but the schema didn't list it; ops queues filtering by status would miss disputed rows).

### New unit tests (23 cases)
- `src/services/stripe/__tests__/helpers.test.ts` — `generateOrderNumber` format + `buildCheckoutUrls` construction
- `src/app/api/webhooks/stripe/__tests__/idempotency.test.ts` — locks in the webhook's idempotency predicate (skip-if-paid), full-vs-partial refund detection, and checkout-only-draft precondition

Pure-function tests — no Stripe API calls.

## What this PR explicitly does NOT do

- ❌ No new activation surfaces (Apply For Me stays only on `/recommendations`, deliberately NOT wired into `/playbook` or `/profile/strategy` until the runbook completes)
- ❌ No live Stripe integration tests
- ❌ No fulfillment queue implementation
- ❌ No ops UI page

## Recommended order to go live

1. Apply this PR
2. Seed `state_fee_schedules` and `service_fee_config`
3. Run the 6-step runbook in `docs/AUTO_APPLY_AUDIT.md`
4. Replace the `console.log` at webhook line 218-223 with a real BullMQ enqueue
5. Add an `/admin/orders` or `/ops/orders` UI
6. **Only then** wire Apply For Me into Playbook + Annual Strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)