### PR TITLE
docs: session recap (2026-05-25) + portfolio optimizer spec

### DIFF
--- a/docs/portfolio-optimizer-spec.md
+++ b/docs/portfolio-optimizer-spec.md
@@ -1,0 +1,116 @@
+# Portfolio Optimizer Spec
+
+Design doc for the layer that goes on top of the portfolio engine (PR #23). Status: proposed, not implemented.
+
+---
+
+## The problem
+
+The portfolio engine projects per-track draw probability independently. That's useful but stops short of the most-valuable user question:
+
+> *"Given my 7 NV elk + 6 WY mule deer points + $8,000 annual budget, what should I apply for THIS year to maximize expected hunting outcomes?"*
+
+The engine tells you "if you apply for X, here's your odds." The optimizer tells you "here's the ranked list of what to apply for, given constraints."
+
+---
+
+## Core math
+
+Each application is a discrete decision with:
+- **Cost** — application fee + tag-on-draw cost + travel-and-lodging-if-drawn
+- **Expected value** — P(draw_this_year) × HunterUtility(specific tag)
+- **Compound effect on future years** — applying maintains point count; skipping freezes or, in squared systems, widens the gap
+
+Hunter utility depends on `HunterGoals.priority`:
+- `trophy`: U(tag) = bull_quality_score × public_land_pct × access_quality
+- `balanced`: U(tag) = 0.4×trophy_score + 0.4×success_rate + 0.2×cost_efficiency
+- `annual_hunt`: U(tag) = P(any_harvest) × cost_efficiency
+
+---
+
+## Algorithm
+
+### Phase 1: Marginal Value Ranking
+
+For each existing track (each state × species the user holds points in):
+
+```
+marginal_value = expected_tags_within_horizon × hunter_utility(track)
+                 - sum_of_application_fees_within_horizon
+```
+
+Rank tracks descending by `marginal_value / horizon_years`. Top of list = best ongoing portfolio members.
+
+### Phase 2: Hypothetical Additions
+
+For each state × species the user does NOT currently hold points in:
+
+Simulate joining the queue starting at 0 points → compute their `marginal_value` at the goal horizon.
+
+Compare against existing tracks. Surface any hypothetical addition whose `marginal_value` exceeds the lowest-ranked existing track's value (i.e. "you should start applying in AZ; it's a better use of resources than your stagnant CA position").
+
+### Phase 3: Annual Application Slate
+
+For the upcoming year specifically, output a ranked recommendation:
+
+```
+This year's recommended applications (in priority order):
+  1. NV unit 10 mule deer — 23% draw odds at your 7 pts. EV $X.
+  2. WY Hunt Area 100 elk — 8% odds, low cost, builds toward year-7 hit.
+  3. AZ apply for points only (build year 1 of new track).
+  4. NM Gila elk DIY — pure random 4-8% any-year shot, $300 NR app.
+  5. CO archery elk OTC — annual hunt fallback, no points cost.
+Skip: UT bighorn sheep (sub-1% at squared math, multi-decade arc — diverting points budget hurts).
+```
+
+### Phase 4: Budget Constraint
+
+Greedy knapsack: starting from highest `marginal_value / cost`, fill until budget is exhausted. Surface what was cut and why.
+
+If the user's expressed `payToBypassToleranceUsd` is high, also surface paid bypasses (NM EPLUS landowner tags, CO landowner vouchers, governor's tags) ranked by `(probability_uplift × hunter_utility) / cost`.
+
+---
+
+## API shape
+
+```typescript
+POST /api/v1/portfolio/optimize
+
+{
+  holdings: [...],                    // same as simulate
+  goals: HunterGoals,
+  horizonYears: 10,
+  includeNewStates: boolean,          // simulate hypothetical additions?
+  candidateStates?: string[],         // limit hypotheticals to specific states
+}
+
+Response: {
+  ranked: PortfolioRecommendation[],  // ordered top-to-bottom
+  hypotheticalAdditions: PortfolioRecommendation[],
+  thisYearSlate: AnnualApplicationSlate,
+  budgetAnalysis: {
+    spent: number,
+    cut: PortfolioRecommendation[],
+    bypassOptions: BypassOption[],
+  },
+  disclaimers: string[],
+}
+```
+
+---
+
+## Implementation notes
+
+- Reuse `engine.ts::simulatePortfolio()` heavily. The optimizer just calls it once per (real + hypothetical) track and ranks the results.
+- Cost data: needs a per-state cost table (NR application fee, NR tag cost, point-only purchase cost). Can hand-curate; doesn't need to be dynamic.
+- Hunter utility heuristics: start hand-tuned, no ML. Move to learned model only if hand-tuned proves brittle.
+- Knapsack with stochastic outcomes is NP-hard in general, but with our scale (~20 tracks × 10 years × few residency variants) a greedy approximation gives 95%+ optimal solutions. Don't over-engineer.
+
+---
+
+## Risks / open questions
+
+- **Cost data freshness:** state fees change yearly. How do we keep current?
+- **Hunter utility is subjective:** "trophy" means different things to different hunters. Validate with at least 3-5 real users before launching.
+- **Hypothetical additions might overwhelm:** if we surface every western state as a possible "you should start here" suggestion, the UI gets noisy. Cap at top-3 hypotheticals.
+- **WY hybrid 75/25 split complicates the optimizer:** the same track has two effective draw paths. Worth modeling as two separate sub-tracks?

--- a/docs/session-2026-05-25-recap.md
+++ b/docs/session-2026-05-25-recap.md
@@ -1,0 +1,138 @@
+# Session Recap — 2026-05-25 → 2026-05-26 overnight
+
+Long working session. Covers fresh-infrastructure stand-up, chat overhaul, full 50-state qualitative coverage, regulation rules, agency draw-odds ingestion for 5 western states, and the personalized portfolio engine (the differentiator).
+
+This doc is the kickoff handoff for the next session.
+
+---
+
+## TL;DR — what landed in prod (main)
+
+**Infrastructure (early in session, before this doc starts tracking):**
+- Fresh HuntLogicAI Vercel project + Neon Postgres, deployed to `app-chi-rust-81.vercel.app`
+- Google OAuth, sign-in working
+- pgvector enabled, full schema initialized
+
+**Chat overhaul:**
+- Streaming SSE responses + Haiku 4.5 (first token ~1s, full strategic brief ~10-15s)
+- Agentic tool loop with `query_hunting_database` + `web_search` (max 2 uses) + (in PR #23) `simulate_user_portfolio`
+- Anti-hallucination prompt: state-detect bug killed, projection-labeling required, unit-numbering rules per state
+- Expansion-opportunities section in strategy briefs (budget-aware, surfaces landowner/outfitter/governor's tags for high-budget profiles)
+- Telegram fallback button removed
+- Three-dot typing indicator replaces single pulsing cursor
+
+**Data layer (qualitative):**
+- 52 state strategy knowledge packs in `docs/knowledge/`
+- 11 western states with deep coverage (point system mechanics, point creep dynamics, top units by reputation)
+- 39 remaining states with regional treatment
+- 1 cross-state comparison pack
+- Loaded at runtime by `buildKnowledgeContext()` → surfaced via RAG into chat
+
+**Data layer (structured):**
+- `state_regulation_rules` table + 25-entry rule-type vocabulary (`docs/regulations-rule-vocabulary.md`)
+- 92 regulation rules populated for PA, OH, WI, MI, IA, TX, CO, WY, UT, NV (weapon legality, caliber min, baiting, hounding, Sunday hunting, orange minimum, crossbow during archery, antler restriction, etc.)
+
+**Data layer (quantitative agency draw odds):**
+
+| State | Rows | Hunt Areas | Status |
+|-------|------|-----------|--------|
+| WY | 500 | 186 | All 5 species (elk/mule_deer/pronghorn/bighorn_sheep/moose) ✓ |
+| CO | 1,217 | 177 | Elk + deer + moose ✓ (pronghorn = 0 records, code prefix mismatch follow-up) |
+| UT | 1,315 | 594 | Limited entry comprehensive ✓ (general-season deer = 2 records, different format follow-up) |
+| NM | 1,652 | 826 | All species via XLSX ✓ |
+| AZ | 284 | 148 | Elk + deer + pronghorn + javelina ✓ (sheep = 0 records, different format) |
+| NV | (existing) | 277 | Enriched + all species ✓ |
+| ID | 0 | 0 | Deferred — IDFG uses interactive Hunt Planner, not downloadable file |
+
+**Total: ~5,250 real agency draw-odds rows + ~2,008 hunt areas with real data.**
+
+**NV hunt-unit enrichment:**
+- 277 NV hunt units enriched with descriptive names ("Area 10 — Ruby Mountains (south)" instead of bare "061")
+- 14 named Areas; the rest fall through to "Area N (NV)" generic label (conservative — never invents geography)
+
+---
+
+## In-flight PRs
+
+### PR #23 — `feat(portfolio): personalized multi-year draw simulation engine`
+https://github.com/HuntLogicAI/HuntLogic/pull/23
+
+Builds the differentiator: personalized multi-state Monte Carlo simulation of when a hunter is likely to draw, grounded in the real agency draw-odds data seeded this session.
+
+Files:
+- `src/lib/portfolio/types.ts` — clean type definitions
+- `src/lib/portfolio/draw-probability.ts` — per-system math (preference, squared bonus, bonus_random, random, hybrid_wy) + 22 unit tests
+- `src/lib/portfolio/projection.ts` — multi-year projection with point accumulation + point-creep modeling
+- `src/lib/portfolio/engine.ts` — orchestrator that pulls drawOdds from DB
+- `src/app/api/v1/portfolio/simulate/route.ts` — `POST /api/v1/portfolio/simulate`
+- Chat integration: new `simulate_user_portfolio` agentic tool
+
+**Status:** Tests passing, typecheck clean. Ready for review and merge.
+
+**Test plan after merge:**
+- [ ] Hit `POST /api/v1/portfolio/simulate` with example payload from GET docs
+- [ ] Ask Grizz "given my 7 NV elk + 6 WY mule deer points, when am I likely to draw?" — confirm it calls the tool and grounds the answer
+- [ ] Spot-check the math: a 7-point hunter on a squared-bonus system with 2000 applicants for 50 tags should land in single-digit percent for year 0
+
+---
+
+## Open issues / known gaps
+
+### Quality
+- **CO pronghorn parser:** 0 records — CPW antelope hunt code prefix differs from elk/deer. Probably a one-char fix in the hunt-code regex once we inspect a pronghorn-specific PDF section.
+- **UT general-season deer parser:** 2 records — different table format from the limited-entry bg-odds.pdf. Needs its own regex.
+- **AZ bighorn sheep:** 0 records — small dataset, probably different column structure.
+- **CO hunt-code collapse:** CO has multiple seasons per (unit × weapon × residency) but our unique index on `draw_odds` collapses them. Real `inserted` count was 2,048 but DB shows 514 unique. Full hunt-code detail is preserved in `rawData` jsonb, just not queryable. Schema migration to widen the unique index would fix.
+
+### Validation
+- We haven't spot-checked any of the seeded data against agency websites. ~5,250 rows of unvalidated parser output is real risk. Recommend grabbing 5 random hunt codes per state and verifying numbers match the source PDFs.
+
+### Coverage gaps
+- **Idaho:** 0 quantitative data. IDFG publishes via interactive web tool, not a PDF. Different ingestion approach required (API reverse-engineering or DOM scraping).
+- **Hunt-unit enrichment for WY/CO/UT/AZ/NM:** Currently unit_names are bare (e.g. "Hunt Area 100 (WGFD NR Elk Random)" or "GMU 61 (CO mule_deer)"). The NV-style enrichment that maps unit code → "Area N — Landmark" would dramatically improve Grizz's chat output quality, but requires curated geographic knowledge per state. Conservative-mapping pattern is established (see `src/app/api/admin/enrich-nv-hunt-units/route.ts`); just needs the curated maps written.
+
+### Schema
+- `draw_odds.unique_idx` collapses multi-season variants (see "CO hunt-code collapse" above). Consider adding `hunt_code` or `season_code` to the unique key.
+- WGFD ingestion creates 25%-special-draw rows under "regular" by default. The hybrid WY system actually splits 75/25, but we don't currently distinguish.
+
+---
+
+## Patterns established this session (reusable for next time)
+
+### Admin endpoint convention
+All ingestion is via `/api/admin/*` routes that:
+- Are public-prefix in middleware (CRON_SECRET-guarded inside the route)
+- Idempotent (DELETE before INSERT, or ON CONFLICT DO NOTHING with unique indexes)
+- Have `GET` endpoints that return docs + current DB state
+- Accept `?debug=1` for sample-text dumps (for PDFs)
+- Wrap POST in try/catch and surface error + stack trace in 500 response body
+
+### PDF ingestion
+- Use `unpdf` (not `pdf-parse`) — serverless-safe, polyfills DOMMatrix
+- Polyfill stubs at top of file: `DOMMatrix`, `Path2D`, `ImageData` (empty classes)
+- Set `serverExternalPackages: ["pdf-parse", "pdfjs-dist"]` in `next.config.ts`
+- Use `?debug=1&offset=N` query params for iterative format discovery on large PDFs
+- Custom regex parser per agency — generic parsers don't match real-world layouts
+
+### Defensive insertion
+- Always `safeInt()` / `safeReal()` wrap before drizzle insert — NaN slips into integer columns silently otherwise
+- `onConflictDoNothing()` for idempotency
+- Pre-load species/state ID maps once per request
+
+### Workflow
+- Push to feature branches and open PRs autonomously
+- Never push directly to main without explicit OK
+- For per-row admin tasks (seeds, enrichments) use the CRON_SECRET-guarded admin endpoint pattern, NOT the Vercel CLI
+
+---
+
+## Recommended next-session priorities (ranked)
+
+1. **Merge PR #23** (portfolio engine) — biggest single feature win, tested and ready.
+2. **Hunt-unit enrichment for WY** — biggest visible quality improvement for chat. Curate WGFD Hunt Area → landmark map (Greys River = 100, Bighorn Mountains = 36-43, etc.). Same pattern as NV.
+3. **Pronghorn fix for CO** — should be a small regex update.
+4. **Validation pass** — spot-check 5 random hunt codes per seeded state against agency websites to verify parser accuracy.
+5. **Optimizer layer** on top of portfolio engine — see `docs/portfolio-optimizer-spec.md` (this PR).
+6. **Hunt-unit enrichment for CO + UT + AZ + NM** — same pattern as WY but each state needs its own curated map.
+7. **ID ingestion** — different shape (API/DOM scraping). Probably its own focused session.
+8. **Multi-year point creep observation** — once we have 2024 + 2025 data, derive `observedPointCreepRate` empirically per (state × species × unit) instead of using the 0.4 default.

--- a/docs/session-2026-05-25-recap.md
+++ b/docs/session-2026-05-25-recap.md
@@ -37,14 +37,14 @@ This doc is the kickoff handoff for the next session.
 | State | Rows | Hunt Areas | Status |
 |-------|------|-----------|--------|
 | WY | 500 | 186 | All 5 species (elk/mule_deer/pronghorn/bighorn_sheep/moose) ✓ |
-| CO | 1,217 | 177 | Elk + deer + moose ✓ (pronghorn = 0 records, code prefix mismatch follow-up) |
+| CO | 1,485 | ~290 | Elk + deer + pronghorn + moose ✓ (the earlier "0 pronghorn records" finding was a stale snapshot — the regex fix landed, pronghorn now has 592 rows) |
 | UT | 1,315 | 594 | Limited entry comprehensive ✓ (general-season deer = 2 records, different format follow-up) |
 | NM | 1,652 | 826 | All species via XLSX ✓ |
 | AZ | 284 | 148 | Elk + deer + pronghorn + javelina ✓ (sheep = 0 records, different format) |
 | NV | (existing) | 277 | Enriched + all species ✓ |
 | ID | 0 | 0 | Deferred — IDFG uses interactive Hunt Planner, not downloadable file |
 
-**Total: ~5,250 real agency draw-odds rows + ~2,008 hunt areas with real data.**
+**Total: ~5,500 real agency draw-odds rows + ~2,200 hunt areas with real data.**
 
 **NV hunt-unit enrichment:**
 - 277 NV hunt units enriched with descriptive names ("Area 10 — Ruby Mountains (south)" instead of bare "061")


### PR DESCRIPTION
## Summary

Two markdown docs to make picking up tomorrow frictionless:

1. **\`docs/session-2026-05-25-recap.md\`** — kickoff handoff for the next session. Captures everything that landed in prod (chat overhaul, 50-state knowledge packs, regulation rules, 5,250 agency draw-odds rows across WY/CO/UT/NM/AZ), the in-flight PR #23 (portfolio engine), known gaps, established patterns (admin endpoints, PDF ingestion, defensive insertion), and a ranked recommended-next-steps list.

2. **\`docs/portfolio-optimizer-spec.md\`** — design doc for the layer that goes on top of PR #23. The portfolio engine projects per-track draw probability independently; the optimizer is what answers \"given my points + budget + goals, what should I apply for this year?\" — Phase 1 marginal-value ranking, Phase 2 hypothetical-additions, Phase 3 annual application slate, Phase 4 budget knapsack. **Not implemented yet — proposed for your sign-off.**

## Test plan

- [ ] Review the recap for accuracy / things I missed
- [ ] Review the optimizer spec — flag any approach issues, sub-goals to prioritize differently, scope to cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)