### PR TITLE
fix(middleware): allow /api/v1/portfolio through public-prefix gate

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -40,6 +40,11 @@ const PUBLIC_PREFIXES = [
   "/api/v1/map/",
   "/api/v1/ingestion/trigger",
   "/api/v1/ops/auth",
+  // Portfolio engine endpoint handles auth internally — either pulls from
+  // the signed-in user's pointHoldings OR accepts an explicit holdings array
+  // in the body. Listed here so the middleware doesn't bounce body-passed
+  // anonymous calls to /login.
+  "/api/v1/portfolio",
   "/_next",
   "/favicon",
 ];


### PR DESCRIPTION
## Summary

One-line addition to \`PUBLIC_PREFIXES\` in \`src/middleware.ts\` so the portfolio engine endpoint (just merged in PR #23) can be hit anonymously when the caller passes \`holdings\` in the body.

Without this, the middleware 307-redirects to /login before the route's internal auth-or-explicit-holdings logic gets a chance to run.

## Test plan

- [x] Confirmed before the fix: \`curl https://app-chi-rust-81.vercel.app/api/v1/portfolio/simulate\` returns HTTP 307 to /login
- [ ] After merge + deploy: same curl should return JSON docs
- [ ] After merge + deploy: \`POST /api/v1/portfolio/simulate\` with body holdings works for unauthenticated callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)