### PR TITLE
feat(auth): private-beta email allowlist (ALLOWED_EMAILS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,15 @@ RESEND_API_KEY=
 EMAIL_FROM="HuntLogic <noreply@huntlogic.com>"
 
 # -----------------------------------------------------------------------------
+# Access control
+# -----------------------------------------------------------------------------
+# Private-beta allowlist. Comma-separated emails. EMPTY = open to anyone who
+# completes OAuth. When set, only these emails (plus ADMIN_EMAILS) can sign in.
+ALLOWED_EMAILS=
+# Admin emails (gate /admin pages); also always allowed to sign in.
+ADMIN_EMAILS=
+
+# -----------------------------------------------------------------------------
 # AI — Anthropic Claude
 # -----------------------------------------------------------------------------
 ANTHROPIC_API_KEY=

--- a/src/lib/auth/__tests__/allowlist.test.ts
+++ b/src/lib/auth/__tests__/allowlist.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { isEmailAllowed, parseEmailList } from "../allowlist";
+
+describe("parseEmailList", () => {
+  it("normalizes, trims, lowercases, and drops blanks", () => {
+    const set = parseEmailList(" A@x.com, b@x.com ,,  C@X.com ");
+    expect([...set].sort()).toEqual(["a@x.com", "b@x.com", "c@x.com"]);
+  });
+
+  it("returns an empty set for undefined/empty", () => {
+    expect(parseEmailList(undefined).size).toBe(0);
+    expect(parseEmailList("").size).toBe(0);
+    expect(parseEmailList("   ").size).toBe(0);
+  });
+});
+
+describe("isEmailAllowed", () => {
+  it("allows anyone when no allowlist is configured (open beta)", () => {
+    expect(isEmailAllowed("random@person.com", "", "")).toBe(true);
+    expect(isEmailAllowed("random@person.com", undefined, undefined)).toBe(true);
+  });
+
+  it("allows only listed emails when allowlist is set", () => {
+    const allow = "mitch@recademics.com, mitch.strobl1@gmail.com";
+    expect(isEmailAllowed("mitch.strobl1@gmail.com", allow, "")).toBe(true);
+    expect(isEmailAllowed("nope@stranger.com", allow, "")).toBe(false);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    const allow = "Mitch.Strobl1@Gmail.com";
+    expect(isEmailAllowed("  mitch.strobl1@gmail.com ", allow, "")).toBe(true);
+  });
+
+  it("always lets admins through even if not in the allowlist", () => {
+    const allow = "someone@beta.com";
+    const admins = "owner@huntlogic.ai";
+    expect(isEmailAllowed("owner@huntlogic.ai", allow, admins)).toBe(true);
+  });
+});

--- a/src/lib/auth/allowlist.ts
+++ b/src/lib/auth/allowlist.ts
@@ -1,0 +1,38 @@
+// =============================================================================
+// Beta access allowlist
+// =============================================================================
+// Gates who can sign in during the private beta. Driven by the ALLOWED_EMAILS
+// env var (comma-separated). Behavior:
+//   - ALLOWED_EMAILS empty/unset  → app is OPEN (anyone who completes OAuth).
+//   - ALLOWED_EMAILS set          → only those emails (plus ADMIN_EMAILS, so an
+//                                    admin is never locked out) may sign in.
+//
+// Kept as a pure function so the decision is unit-testable without touching the
+// auth/DB machinery.
+// =============================================================================
+
+/** Parse a comma-separated email env value into a normalized lowercase set. */
+export function parseEmailList(raw?: string | null): Set<string> {
+  return new Set(
+    (raw ?? "")
+      .split(",")
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Decide whether `email` may sign in, given the raw ALLOWED_EMAILS and
+ * ADMIN_EMAILS env values. An empty allowlist means the app is open to all.
+ */
+export function isEmailAllowed(
+  email: string,
+  allowedRaw?: string | null,
+  adminRaw?: string | null,
+): boolean {
+  const allow = parseEmailList(allowedRaw);
+  if (allow.size === 0) return true; // open beta — no gating configured
+  const normalized = email.trim().toLowerCase();
+  if (allow.has(normalized)) return true;
+  return parseEmailList(adminRaw).has(normalized);
+}

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -15,6 +15,7 @@ import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema/users";
 import { HuntLogicDrizzleAdapter } from "./adapter";
 import { config } from "@/lib/config";
+import { isEmailAllowed } from "./allowlist";
 
 // =============================================================================
 // Type augmentation for Auth.js
@@ -152,6 +153,13 @@ export const authConfig: NextAuthConfig = {
      */
     async signIn({ user, account }) {
       if (!user.email) return false;
+
+      // Private-beta gate. When ALLOWED_EMAILS is set, only listed emails
+      // (plus ADMIN_EMAILS) may sign in. Empty allowlist = open to all.
+      if (!isEmailAllowed(user.email, process.env.ALLOWED_EMAILS, process.env.ADMIN_EMAILS)) {
+        console.warn(`[auth] Blocked sign-in — not on beta allowlist: ${user.email}`);
+        return false;
+      }
 
       try {
         // Check if user exists in our DB


### PR DESCRIPTION
## Summary
Gate sign-in during the private beta with an `ALLOWED_EMAILS` allowlist, so you can publish the OAuth app (URL "just works") while keeping access to invited testers.

- **Empty `ALLOWED_EMAILS`** → app is open to anyone who completes OAuth (current behavior, unchanged).
- **`ALLOWED_EMAILS` set** → only those emails (plus `ADMIN_EMAILS`, so an admin is never locked out) may sign in. Everyone else is bounced at the NextAuth `signIn` callback.
- Pure `isEmailAllowed()` helper (case/whitespace-insensitive) + unit tests.

## How access works after this
| Layer | Lock |
|---|---|
| Google OAuth | Must be a test user **or** OAuth published → reaches our app |
| App allowlist (this PR) | Email must be in `ALLOWED_EMAILS`/`ADMIN_EMAILS` |

So the recommended beta setup: **publish the OAuth consent screen** (any Google account can reach us) + **set `ALLOWED_EMAILS`** (only invited testers actually get in).

## Test plan
- [x] typecheck clean
- [x] lint 0 errors
- [x] `vitest` — allowlist suite (6 tests) green
- [ ] Post-deploy: set `ALLOWED_EMAILS`, confirm a listed email gets in and a non-listed email is bounced

🤖 Generated with [Claude Code](https://claude.com/claude-code)